### PR TITLE
Example and non-entity semi-colon issue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,7 +79,7 @@ fn main() {
     let mut depth = 0;
     for e in parser.events() {
         match e {
-            StartElement(name, _, _) => {
+            StartElement { ref name, ref attributes, ref namespace } => {
                 println!("{}/{}", indent(depth), name);
                 depth += 1;
             }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -439,6 +439,11 @@ impl PullParser {
                 self.append_str_continue(t.to_string().as_slice())
             }
 
+            ReferenceEnd => { // Semi-colon in a text outside an entity
+                self.inside_whitespace = false;
+                self.append_str_continue(";")
+            }
+
             CommentStart if self.config.coalesce_characters && self.config.ignore_comments => {
                 // We need to disable lexing errors inside comments
                 self.lexer.disable_errors();


### PR DESCRIPTION
The example in Readme.md does not compile with Rust nightly, I used the syntax I found in the project instead.

Also a XML containing a semi-colon outside an entity (ex: <a>;</a>) gives an error:
Error(row: 1, col: 6, message: Unexpected token: ;)
I tried a fix, but not sure if in line with the project.
