### PR TITLE
`..` -> `...` and fixed deprecation warnings

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -107,7 +107,7 @@ impl Name {
         }
     }
 
-    /// Returns a `Name` instance representing qualified name with the 
+    /// Returns a `Name` instance representing qualified name with the
     /// given prefix and namespace URI.
     #[inline]
     pub fn new(name: &str, prefix: &str, namespace: &str) -> Name {
@@ -201,7 +201,7 @@ impl fmt::Show for XmlVersion {
 }
 
 
-/// Checks whether the given character is a white space character (`S`) 
+/// Checks whether the given character is a white space character (`S`)
 /// as is defined by XML 1.1 specification, [section 2.3][1].
 ///
 /// [1]: http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-common-syn
@@ -218,13 +218,13 @@ pub fn is_whitespace_char(c: char) -> bool {
 /// [1]: http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-common-syn
 pub fn is_name_start_char(c: char) -> bool {
     match c {
-        ':' | 'A'..'Z' | '_' | 'a'..'z' |
-        '\xC0'..'\xD6' | '\xD8'..'\xF6' | '\xF8'..'\u02FF' |
-        '\u0370'..'\u037D' | '\u037F'..'\u1FFF' |
-        '\u200C'..'\u200D' | '\u2070'..'\u218F' |
-        '\u2C00'..'\u2FEF' | '\u3001'..'\uD7FF' |
-        '\uF900'..'\uFDCF' | '\uFDF0'..'\uFFFD' |
-        '\U00010000'..'\U000EFFFF' => true,
+        ':' | 'A'...'Z' | '_' | 'a'...'z' |
+        '\xC0'...'\xD6' | '\xD8'...'\xF6' | '\xF8'...'\u02FF' |
+        '\u0370'...'\u037D' | '\u037F'...'\u1FFF' |
+        '\u200C'...'\u200D' | '\u2070'...'\u218F' |
+        '\u2C00'...'\u2FEF' | '\u3001'...'\uD7FF' |
+        '\uF900'...'\uFDCF' | '\uFDF0'...'\uFFFD' |
+        '\U00010000'...'\U000EFFFF' => true,
         _ => false
     }
 }
@@ -236,8 +236,8 @@ pub fn is_name_start_char(c: char) -> bool {
 pub fn is_name_char(c: char) -> bool {
     match c {
         _ if is_name_start_char(c) => true,
-        '-' | '.' | '0'..'9' | '\xB7' | 
-        '\u0300'..'\u03F6' | '\u203F'..'\u2040' => true,
+        '-' | '.' | '0'...'9' | '\xB7' |
+        '\u0300'...'\u03F6' | '\u203F'...'\u2040' => true,
         _ => false
     }
 }
@@ -283,7 +283,7 @@ pub fn escape_str(s: &str) -> String {
             '"'  => result.push_str("&quot;"),
             '\'' => result.push_str("&apos;"),
             '&'  => result.push_str("&amp;"),
-            _    => result.push_char(c)
+            _    => result.push(c)
         }
     }
     result
@@ -312,11 +312,11 @@ mod tests {
     #[test]
     fn attribute_show() {
         let attr = Attribute::new(
-            Name::new("attribute", "n", "urn:namespace"), 
+            Name::new("attribute", "n", "urn:namespace"),
             "its value with > & \" ' < weird symbols"
         );
         assert_eq!(
-            attr.to_string().as_slice(), 
+            attr.to_string().as_slice(),
             "{urn:namespace}n:attribute=\"its value with &gt; &amp; &quot; &apos; &lt; weird symbols\""
         )
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -157,16 +157,16 @@ impl NamespaceStack {
     #[inline]
     pub fn peek<'a>(&'a mut self) -> &'a mut Namespace {
         let NamespaceStack(ref mut nst) = *self;
-        nst.mut_last().unwrap()
+        nst.last_mut().unwrap()
     }
 
     /// Puts a mapping into the topmost namespace in this stack.
     ///
-    /// This method does not override a mapping in the topmost namespace if it is 
+    /// This method does not override a mapping in the topmost namespace if it is
     /// already present, however, it does not depend on other namespaces in the stack,
     /// so it is possible to put a mapping which is present in lower namespaces.
     ///
-    /// Returns a boolean flag indicating whether the topmost namespace 
+    /// Returns a boolean flag indicating whether the topmost namespace
     /// already contained the given prefix.
     ///
     /// # Parameters
@@ -179,7 +179,7 @@ impl NamespaceStack {
     #[inline]
     pub fn put(&mut self, prefix: Option<String>, uri: String) -> bool {
         let NamespaceStack(ref mut nst) = *self;
-        nst.mut_last().unwrap().put(prefix, uri)
+        nst.last_mut().unwrap().put(prefix, uri)
     }
 
     /// Performs a search for the given prefix in the whole stack.
@@ -244,7 +244,7 @@ impl<'a> Iterator<(Option<&'a str>, &'a str)> for NamespaceStackMappings<'a> {
                 // If the current key is used, go to the next one
                 self.next()
             } else {
-                // Otherwise insert the current key to the set of used keys and 
+                // Otherwise insert the current key to the set of used keys and
                 // return the mapping
                 self.used_keys.insert(k);
                 Some((k, v))
@@ -264,7 +264,7 @@ impl<'a> Iterator<(Option<&'a str>, &'a str)> for NamespaceStackMappings<'a> {
 impl<'a> NamespaceIterable<'a, NamespaceStackMappings<'a>> for NamespaceStack {
     fn uri_mappings(&'a self) -> NamespaceStackMappings<'a> {
         let NamespaceStack(ref nst) = *self;
-        NamespaceStackMappings { 
+        NamespaceStackMappings {
             namespaces: nst.iter().rev(),
             current_namespace: None,
             used_keys: HashSet::new()

--- a/src/reader/events.rs
+++ b/src/reader/events.rs
@@ -13,7 +13,7 @@ use namespace::Namespace;
 /// elements of an XML document.
 #[deriving(PartialEq, Clone)]
 pub enum XmlEvent {
-    /// Corresponds to XML document declaration. 
+    /// Corresponds to XML document declaration.
     ///
     /// This event is always emitted before any other event (except `Error`). It is emitted
     /// even if the actual declaration is not present in the document.
@@ -40,7 +40,7 @@ pub enum XmlEvent {
 
     /// Denotes to the end of the document stream.
     ///
-    /// This event is always emitted after any other event (except `Error`). After it 
+    /// This event is always emitted after any other event (except `Error`). After it
     /// is emitted for the first time, it will always be emitted on next event pull attempts.
     EndDocument,
 
@@ -48,24 +48,24 @@ pub enum XmlEvent {
     ///
     /// This event contains a processing instruction target (`name`) and opaque `data`. It
     /// is up to the application to process them.
-    ProcessingInstruction { 
+    ProcessingInstruction {
         /// Processing instruction target.
-        pub name: String, 
+        pub name: String,
 
         /// Processing instruction content.
-        pub data: Option<String> 
+        pub data: Option<String>
     },
 
     /// Denotes a beginning of an XML element.
     ///
     /// This event is emitted after parsing opening tags or after parsing bodiless tags. In the
     /// latter case `EndElement` event immediately follows.
-    StartElement { 
+    StartElement {
         /// Qualified name of the element.
         pub name: Name,
 
         /// A list of attributes associated with the element.
-        /// 
+        ///
         /// Currently attributes are not checked for duplicates (TODO)
         pub attributes: Vec<Attribute>,
 

--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -135,17 +135,17 @@ impl Emitter {
 
     #[inline]
     fn set_wrote_text(&mut self) {
-        *self.indent_stack.mut_last().unwrap() = WROTE_TEXT;
+        *self.indent_stack.last_mut().unwrap() = WROTE_TEXT;
     }
 
     #[inline]
     fn set_wrote_markup(&mut self) {
-        *self.indent_stack.mut_last().unwrap() = WROTE_MARKUP;
+        *self.indent_stack.last_mut().unwrap() = WROTE_MARKUP;
     }
 
     #[inline]
     fn reset_state(&mut self) {
-        *self.indent_stack.mut_last().unwrap() = WROTE_NOTHING;
+        *self.indent_stack.last_mut().unwrap() = WROTE_NOTHING;
     }
 
     fn write_newline<W: Writer>(&mut self, target: &mut W, level: uint) -> EmitterResult<()> {
@@ -242,10 +242,10 @@ impl Emitter {
         )
     }
 
-    fn emit_start_element_initial<'a, W: Writer, 
+    fn emit_start_element_initial<'a, W: Writer,
                                   N: NamespaceIterable<'a, I>,
                                   I: Iterator<(Option<&'a str>, &'a str)>
-                                 >(&mut self, target: &mut W, name: &Name, attributes: &[Attribute], 
+                                 >(&mut self, target: &mut W, name: &Name, attributes: &[Attribute],
                                    namespace: &'a N) -> EmitterResult<()> {
         try!(self.check_document_started(target));
 
@@ -258,27 +258,27 @@ impl Emitter {
         self.emit_attributes(target, attributes)
     }
 
-    pub fn emit_empty_element<'a, W: Writer, 
+    pub fn emit_empty_element<'a, W: Writer,
                               N: NamespaceIterable<'a, I>,
                               I: Iterator<(Option<&'a str>, &'a str)>
-                             >(&mut self, target: &mut W, name: &Name, attributes: &[Attribute], 
+                             >(&mut self, target: &mut W, name: &Name, attributes: &[Attribute],
                                namespace: &'a N) -> EmitterResult<()> {
         try!(self.emit_start_element_initial(target, name, attributes, namespace));
 
         io_wrap(write!(target, "/>"))
     }
 
-    pub fn emit_start_element<'a, W: Writer, 
+    pub fn emit_start_element<'a, W: Writer,
                               N: NamespaceIterable<'a, I>,
                               I: Iterator<(Option<&'a str>, &'a str)>
-                             >(&mut self, target: &mut W, name: &Name, attributes: &[Attribute], 
+                             >(&mut self, target: &mut W, name: &Name, attributes: &[Attribute],
                                namespace: &'a N) -> EmitterResult<()> {
         try!(self.emit_start_element_initial(target, name, attributes, namespace));
 
         io_wrap(write!(target, ">"))
     }
 
-    pub fn emit_namespace_attributes<'a, W: Writer, 
+    pub fn emit_namespace_attributes<'a, W: Writer,
                                      N: NamespaceIterable<'a, I>,
                                      I: Iterator<(Option<&'a str>, &'a str)>
                                     >(&mut self, target: &mut W, namespace: &'a N) -> EmitterResult<()> {


### PR DESCRIPTION
Rust master changed ranges in pattern matching to be three '.'s instead of two.

My editor also automatically stripped out a few trailing spaces in the files that were edited.

I left the dead_code and unused_variable warnings alone because it looked like there was some WIP stuff.
