### PR TITLE
Update for rustc f9fc49c06 2014-10-10 00:07:08 +0000

### DIFF
--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -2,11 +2,11 @@ use std::iter::Rev;
 use core::slice::Items;
 use std::collections::hashmap::{HashMap, HashSet, Entries};
 
-pub static NS_XMLNS_PREFIX: &'static str = "xmlns";
-pub static NS_XMLNS_URI: &'static str    = "http://www.w3.org/2000/xmlns/";
-pub static NS_XML_PREFIX: &'static str   = "xml";
-pub static NS_XML_URI: &'static str      = "http://www.w3.org/XML/1998/namespace";
-pub static NS_EMPTY_URI: &'static str    = "";
+pub const NS_XMLNS_PREFIX: &'static str = "xmlns";
+pub const NS_XMLNS_URI: &'static str    = "http://www.w3.org/2000/xmlns/";
+pub const NS_XML_PREFIX: &'static str   = "xml";
+pub const NS_XML_URI: &'static str      = "http://www.w3.org/XML/1998/namespace";
+pub const NS_EMPTY_URI: &'static str    = "";
 
 /// Denotes something which contains namespace URI mappings.
 ///

--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -110,9 +110,9 @@ macro_rules! if_present(
 
 bitflags!(
     flags IndentFlags: u8 {
-        static WROTE_NOTHING = 0,
-        static WROTE_MARKUP  = 1,
-        static WROTE_TEXT    = 2
+        const WROTE_NOTHING = 0,
+        const WROTE_MARKUP  = 1,
+        const WROTE_TEXT    = 2
     }
 )
 


### PR DESCRIPTION
(note that your library is a dependency of `gl-rs`, which is itself a dependency of 95 % of the gamedev-related stuff in rust, so it's great if you merge these PRs quickly)
