### PR TITLE
Avoid warning; tuple_indexing now part of language.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //#![warn(missing_doc)]
 #![forbid(non_camel_case_types)]
-#![feature(macro_rules, tuple_indexing)]
+#![feature(macro_rules)]
 
 //! This crate currently provides almost XML 1.0/1.1-compliant pull parser.
 


### PR DESCRIPTION
Fixed warning:
"warning: feature has been added to Rust, directive not necessary"
