### PR TITLE
Changes to implement latest nightly build macro rules

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -84,7 +84,7 @@ impl fmt::Show for Name {
                     None => {}
                 }
             )
-        )
+        );
 
         try_opt!(self.namespace.as_ref().map(|namespace| {
             write!(f, "{{{}}}", namespace)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! for_each(
             }
         }
     )
-)
+);
 
 macro_rules! gen_setters(
     ($target:ty, $($field:ident : $t:ty),+) => ($(
@@ -23,5 +23,4 @@ macro_rules! gen_setters(
             }
         }
     )+)
-)
-
+);

--- a/src/reader/config.rs
+++ b/src/reader/config.rs
@@ -82,4 +82,4 @@ gen_setters!(ParserConfig,
     cdata_to_characters: bool,
     ignore_comments: bool,
     coalesce_characters: bool
-)
+);

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -185,7 +185,7 @@ macro_rules! dispatch_on_enum_state(
             }
         }
     )
-)
+);
 
 /// `PullLexer` is a lexer for XML documents, which implements pull API.
 ///
@@ -267,7 +267,7 @@ impl PullLexer {
                 Some(t) => return Some(t),
                 None    => {}  // continue
             }
-        })
+        });
 
         // Handle end of stream
         self.eof_handled = true;
@@ -489,7 +489,7 @@ mod tests {
                 assert_eq!(Some(Ok($e)), $lex.next_token(&mut $buf));
              )+
         })
-    )
+    );
 
     macro_rules! assert_err(
         (for $lex:ident and $buf:ident expect row $r:expr col $c:expr, $s:expr) => ({
@@ -501,13 +501,13 @@ mod tests {
             assert_eq!($c as uint, err.col());
             assert_eq!($s, err.msg());
         })
-    )
+    );
 
     macro_rules! assert_none(
         (for $lex:ident and $buf:ident) => (
-            assert_eq!(None, $lex.next_token(&mut $buf))
+            assert_eq!(None, $lex.next_token(&mut $buf));
         )
-    )
+    );
 
     fn make_buf(s: String) -> MemReader {
         MemReader::new(s.into_bytes())
@@ -576,7 +576,7 @@ mod tests {
             Token::Character('s')
             Token::Character('p')
             Token::ReferenceEnd
-        )
+        );
         assert_none!(for lex and buf);
     }
 
@@ -601,7 +601,7 @@ mod tests {
             Token::Character(']')
             Token::Character('z')
             Token::Chunk("]]")
-        )
+        );
         assert_none!(for lex and buf);
     }
 
@@ -626,7 +626,7 @@ mod tests {
             Token::ClosingTagStart
             Token::Character('a')
             Token::TagEnd
-        )
+        );
         assert_none!(for lex and buf);
     }
 
@@ -650,7 +650,7 @@ mod tests {
             Token::Character('z')
             Token::TagEnd
             Token::Whitespace(' ')
-        )
+        );
         assert_none!(for lex and buf)
     }
 
@@ -662,7 +662,7 @@ mod tests {
                 assert_oks!(for lex and buf $token);
                 assert_none!(for lex and buf);
             })
-        )
+        );
         eof_check!("?"  -> Token::Character('?'));
         eof_check!("/"  -> Token::Character('/'));
         eof_check!("-"  -> Token::Character('-'));
@@ -678,7 +678,7 @@ mod tests {
                 assert_err!(for lex and buf expect row $r col $c, "Unexpected end of stream");
                 assert_none!(for lex and buf);
             })
-        )
+        );
         eof_check!("<"        -> 0, 1);
         eof_check!("<!"       -> 0, 2);
         eof_check!("<!-"      -> 0, 3);
@@ -736,7 +736,7 @@ mod tests {
             );
             assert_none!(for lex and buf);
         })
-    )
+    );
 
     #[test]
     fn error_in_cdata_started() {

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -202,7 +202,7 @@ macro_rules! gen_takes(
         }
         )+
     )
-)
+);
 
 gen_takes!(
     name         -> take_name, String, String::new();
@@ -216,12 +216,12 @@ gen_takes!(
 
     attr_name    -> take_attr_name, Option<Name>, None;
     attributes   -> take_attributes, Vec<AttributeData>, vec!()
-)
+);
 
 macro_rules! self_error(
     ($this:ident; $msg:expr) => ($this.error($msg.to_string()));
     ($this:ident; $fmt:expr, $($arg:expr),+) => ($this.error(format!($fmt, $($arg),+)))
-)
+);
 
 impl PullParser {
     /// Returns next event read from the given buffer.
@@ -263,7 +263,7 @@ impl PullParser {
                     return ev;
                 }
             }
-        })
+        });
 
         // Handle end of stream
         let ev = if self.depth() == 0 {
@@ -625,7 +625,7 @@ impl PullParser {
         macro_rules! unexpected_token(
             ($this:expr; $t:expr) => (Some($this.error(format!("Unexpected token inside XML declaration: {}", $t))));
             ($t:expr) => (unexpected_token!(self; $t));
-        )
+        );
 
         #[inline]
         fn emit_start_document(this: &mut PullParser) -> Option<XmlEvent> {
@@ -796,7 +796,7 @@ impl PullParser {
     }
 
     fn inside_opening_tag(&mut self, t: Token, s: OpeningTagSubstate) -> Option<XmlEvent> {
-        macro_rules! unexpected_token(($t:expr) => (Some(self_error!(self; "Unexpected token inside opening tag: {}", $t))))
+        macro_rules! unexpected_token(($t:expr) => (Some(self_error!(self; "Unexpected token inside opening tag: {}", $t))));
         match s {
             OpeningTagSubstate::InsideName => self.read_qualified_name(t, QualifiedNameTarget::OpeningTagNameTarget, |this, token, name| {
                 match name.prefix_ref() {
@@ -1061,7 +1061,7 @@ mod tests {
                 e => panic!("Unexpected event: {}", e)
             }
         )
-    )
+    );
 
     macro_rules! test_data(
         ($d:expr) => ({
@@ -1070,7 +1070,7 @@ mod tests {
             let p = new_parser();
             (r, p)
         })
-    )
+    );
 
     #[test]
     fn semicolon_in_attribute_value__issue_3() {

--- a/src/writer/config.rs
+++ b/src/writer/config.rs
@@ -28,4 +28,4 @@ gen_setters!(EmitterConfig,
     write_document_declaration: bool,
     normalize_empty_elements: bool,
     cdata_to_characters: bool
-)
+);

--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -85,7 +85,7 @@ macro_rules! io_try(
             Err(err) => return Err(io_error(err))
         }
     )
-)
+);
 
 macro_rules! io_chain(
     ($e:expr) => (io_wrap($e));
@@ -93,7 +93,7 @@ macro_rules! io_chain(
         io_try!($e);
         io_chain!($($rest),+)
     })
-)
+);
 
 macro_rules! wrapped_with(
     ($_self:ident; $before_name:ident ($arg:expr) and $after_name:ident, $body:expr) => ({
@@ -102,11 +102,11 @@ macro_rules! wrapped_with(
         $_self.$after_name();
         result
     })
-)
+);
 
 macro_rules! if_present(
     ($opt:ident, $body:expr) => ($opt.map(|$opt| $body).unwrap_or(Ok(())))
-)
+);
 
 bitflags!(
     flags IndentFlags: u8 {
@@ -114,7 +114,7 @@ bitflags!(
         const WROTE_MARKUP  = 1,
         const WROTE_TEXT    = 2
     }
-)
+);
 
 impl Emitter {
     /// Returns current state of namespaces.


### PR DESCRIPTION
Implemented the new macro rule that requires semicolons on the end of macros, issued in the latest nightly build of rustc
