### PR TITLE
Change &str.into_string() to &str.to_owned()

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use name::{Name, OwnedName};
 use escape::escape_str;
+use std::borrow::ToOwned;
 
 /// A borrowed version of an XML attribute.
 ///
@@ -26,7 +27,7 @@ impl<'a> Attribute<'a> {
     pub fn to_owned(&self) -> OwnedAttribute {
         OwnedAttribute {
             name: self.name.to_owned(),
-            value: self.value.into_string()
+            value: self.value.to_owned()
         }
     }
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
+use std::borrow::ToOwned;
 
 use util::{OptionBorrowExt, IntoOwned};
 
@@ -48,9 +49,9 @@ impl<'a> Name<'a> {
     /// Returns an owned variant of the qualified name.
     pub fn to_owned(&self) -> OwnedName {
         OwnedName {
-            local_name: self.local_name.into_string(),
-            namespace: self.namespace.map(|s| s.into_string()),
-            prefix: self.prefix.map(|s| s.into_string())
+            local_name: self.local_name.to_owned(),
+            namespace: self.namespace.map(|s| s.to_owned()),
+            prefix: self.prefix.map(|s| s.to_owned())
         }
     }
 
@@ -82,7 +83,7 @@ impl<'a> Name<'a> {
     pub fn to_repr(&self) -> String {
         match self.prefix {
             Some(prefix) => format!("{}:{}", prefix, self.local_name),
-            None => self.local_name.into_string()
+            None => self.local_name.to_owned()
         }
     }
 }
@@ -129,7 +130,7 @@ impl OwnedName {
         }
     }
 
-    /// Returns a new `OwnedName` instance representing a qualified name with or without 
+    /// Returns a new `OwnedName` instance representing a qualified name with or without
     /// a prefix and with a namespace URI.
     #[inline]
     pub fn qualified<S1, S2, S3>(local_name: S1, namespace: S2, prefix: Option<S3>) -> OwnedName
@@ -180,9 +181,9 @@ impl FromStr for OwnedName {
         let r = match (it.next(), it.next(), it.next()) {
             (Some(prefix), Some(local_name), None) if !prefix.is_empty() &&
                                                       !local_name.is_empty() =>
-                Some((local_name.into_string(), Some(prefix.into_string()))),
+                Some((local_name.to_owned(), Some(prefix.to_owned()))),
             (Some(local_name), None, None) if !local_name.is_empty() =>
-                Some((local_name.into_string(), None)),
+                Some((local_name.to_owned(), None)),
             (_, _, _) => None
         };
         r.map(|(local_name, prefix)| OwnedName {

--- a/src/writer/config.rs
+++ b/src/writer/config.rs
@@ -1,5 +1,7 @@
 //! Contains emitter configuration structure.
 
+use std::borrow::ToOwned;
+
 /// Emitter configuration structure.
 ///
 /// This structure contains various options which control XML document emitter behavior.
@@ -49,14 +51,14 @@ impl EmitterConfig {
     /// You can tweak default options with builder-like pattern:
     /// ```rust
     /// let config = EmitterConfig::new()
-    ///     .line_separator("\r\n".into_string())
+    ///     .line_separator("\r\n".to_owned())
     ///     .perform_indent(true)
     ///     .normalize_empty_elements(false);
     /// ```
     pub fn new() -> EmitterConfig {
         EmitterConfig {
-            line_separator: "\n".into_string(),
-            indent_string: "  ".into_string(),  // two spaces
+            line_separator: "\n".to_owned(),
+            indent_string: "  ".to_owned(),  // two spaces
             perform_indent: false,
             write_document_declaration: true,
             normalize_empty_elements: true,


### PR DESCRIPTION
Fixes some warnings
