### PR TITLE
Fix rename hash_map::Entries -> hash_map::Iter

### DIFF
--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,6 +1,7 @@
 use std::iter::Rev;
 use core::slice::Iter;
-use std::collections::hash_map::{HashMap, Entries, Entry};
+use std::collections::hash_map::{HashMap, Entry};
+use std::collections::hash_map::Iter as Entries;
 use std::collections::HashSet;
 
 use util::{OptionBorrowExt, IntoOwned, IteratorClonedPairwiseExt};


### PR DESCRIPTION
Fixes compiler errors in the latest nightly.