### PR TITLE
New Borrow + IntoChanged, remove BorrowFrom, juggle types.

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow::{Borrowed, Owned};
+use std::iter::IntoIterator;
 use std::string::CowString;
 
 use self::Value::{C, S};
@@ -54,8 +55,8 @@ impl<'a> Process<'a> {
 }
 
 impl<'a> Extend<Value> for Process<'a> {
-    fn extend<I: Iterator<Item=Value>>(&mut self, it: I) {
-        for v in it.enumerate() {
+    fn extend<I: IntoIterator<Item=Value>>(&mut self, it: I) {
+        for v in it.into_iter().enumerate() {
             self.process(v);
         }
     }

--- a/src/name.rs
+++ b/src/name.rs
@@ -122,7 +122,7 @@ impl OwnedName {
 
     /// Returns a new `OwnedName` instance representing a plain local name.
     #[inline]
-    pub fn local<'s, S: IntoCow<'s, String, str>>(local_name: S) -> OwnedName {
+    pub fn local<'s, S: IntoCow<'s, str>>(local_name: S) -> OwnedName {
         OwnedName {
             local_name: local_name.into_cow().into_owned(),
             namespace: None,
@@ -135,9 +135,9 @@ impl OwnedName {
     #[inline]
     pub fn qualified<'s1, 's2, 's3, S1, S2, S3>(local_name: S1, namespace: S2, 
                                                 prefix: Option<S3>) -> OwnedName
-            where S1: IntoCow<'s1, String, str>,
-                  S2: IntoCow<'s2, String, str>,
-                  S3: IntoCow<'s3, String, str> {
+            where S1: IntoCow<'s1, str>,
+                  S2: IntoCow<'s2, str>,
+                  S3: IntoCow<'s3, str> {
         OwnedName {
             local_name: local_name.into_cow().into_owned(),
             namespace: Some(namespace.into_cow().into_owned()),

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -71,7 +71,7 @@ impl Namespace {
     /// `true` if `prefix` has been inserted successfully; `false` if the `prefix`
     /// was already present in the namespace.
     pub fn put<'s1, 's2, S1, S2>(&mut self, prefix: Option<S1>, uri: S2) -> bool
-            where S1: IntoCow<'s1, String, str>, S2: IntoCow<'s2, String, str> {
+            where S1: IntoCow<'s1, str>, S2: IntoCow<'s2, str> {
         match self.0.entry(prefix.map(|v| v.into_cow().into_owned())) {
             Entry::Occupied(_) => false,
             Entry::Vacant(ve) => {
@@ -95,7 +95,7 @@ impl Namespace {
     /// `Some(uri)` with `uri` being a previous URI assigned to the `prefix`, or
     /// `None` if such prefix was not present in the namespace before.
     pub fn force_put<'s1, 's2, S1, S2>(&mut self, prefix: Option<S1>, uri: S2) -> Option<String>
-            where S1: IntoCow<'s1, String, str>, S2: IntoCow<'s2, String, str> {
+            where S1: IntoCow<'s1, str>, S2: IntoCow<'s2, str> {
         self.0.insert(prefix.map(|v| v.into_cow().into_owned()), uri.into_cow().into_owned())
     }
 


### PR DESCRIPTION
There are changes to public-facing types in `src/util.rs` - the old way needed a bunch of `PhantomFn` and `PhantomData` type annotations.