### PR TITLE
Make the Writer param not require ownership

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,8 +55,6 @@ which allow to create a parser from string or a byte vector.
 over events:
 
 ```rust
-extern crate xml;
-
 use std::old_io::{File, BufferedReader};
 
 use xml::reader::EventReader;

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -10,19 +10,19 @@ mod emitter;
 pub mod config;
 pub mod events;
 
-pub struct EventWriter<W> {
-    sink: W,
+pub struct EventWriter<'a, W: 'a> {
+    sink: &'a mut W,
     emitter: Emitter
 }
 
-impl<W: Writer> EventWriter<W> {
+impl<'a, W: Writer> EventWriter<'a, W> {
     #[inline]
-    pub fn new(sink: W) -> EventWriter<W> {
+    pub fn new(sink: &'a mut W) -> EventWriter<'a, W> {
         EventWriter::new_with_config(sink, EmitterConfig::new())
     }
 
     #[inline]
-    pub fn new_with_config(sink: W, config: EmitterConfig) -> EventWriter<W> {
+    pub fn new_with_config(sink: &'a mut W, config: EmitterConfig) -> EventWriter<'a, W> {
         EventWriter {
             sink: sink,
             emitter: Emitter::new(config)
@@ -32,31 +32,31 @@ impl<W: Writer> EventWriter<W> {
     pub fn write(&mut self, event: XmlEvent) -> EventWriterResult<()> {
         match event {
             XmlEvent::StartDocument { version, encoding, standalone } => 
-                self.emitter.emit_start_document(&mut self.sink, version, encoding.unwrap_or("UTF-8"), standalone),
+                self.emitter.emit_start_document(self.sink, version, encoding.unwrap_or("UTF-8"), standalone),
             XmlEvent::ProcessingInstruction { name, data } =>
-                self.emitter.emit_processing_instruction(&mut self.sink, name, data),
+                self.emitter.emit_processing_instruction(self.sink, name, data),
             XmlEvent::StartElement { name, attributes, namespace } =>
-                self.emitter.emit_start_element(&mut self.sink, name, attributes.as_slice(), namespace),
+                self.emitter.emit_start_element(self.sink, name, attributes.as_slice(), namespace),
             XmlEvent::EndElement { name } => 
-                self.emitter.emit_end_element(&mut self.sink, name),
+                self.emitter.emit_end_element(self.sink, name),
             XmlEvent::Comment(content) => 
-                self.emitter.emit_comment(&mut self.sink, content),
+                self.emitter.emit_comment(self.sink, content),
             XmlEvent::CData(content) => 
-                self.emitter.emit_cdata(&mut self.sink, content),
+                self.emitter.emit_cdata(self.sink, content),
             XmlEvent::Characters(content) => 
-                self.emitter.emit_characters(&mut self.sink, content)
+                self.emitter.emit_characters(self.sink, content)
         }
     }
 }
 
-impl EventWriter<MemWriter> {
+impl<'a> EventWriter<'a, MemWriter> {
     #[inline]
-    pub fn new_into_mem(sink: MemWriter) -> EventWriter<MemWriter> {
+    pub fn new_into_mem(sink: &'a mut MemWriter) -> EventWriter<'a, MemWriter> {
         EventWriter::new_into_mem_config(sink, EmitterConfig::new())
     }
 
     #[inline]
-    pub fn new_into_mem_config(sink: MemWriter, config: EmitterConfig) -> EventWriter<MemWriter> {
+    pub fn new_into_mem_config(sink: &'a mut MemWriter, config: EmitterConfig) -> EventWriter<'a, MemWriter> {
         EventWriter::new_with_config(sink, config)
     }
 }
@@ -80,7 +80,7 @@ mod tests {
 
         {
             let mut r = EventReader::new(BufferedReader::new(reader_by_ref(&mut f)));
-            let mut w = EventWriter::new(b.by_ref());
+            let mut w = EventWriter::new(&mut b);
 
             for e in r.events() {
                 match e.as_writer_event() {

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -31,19 +31,19 @@ impl<'a, W: Writer> EventWriter<'a, W> {
 
     pub fn write(&mut self, event: XmlEvent) -> EventWriterResult<()> {
         match event {
-            XmlEvent::StartDocument { version, encoding, standalone } => 
+            XmlEvent::StartDocument { version, encoding, standalone } =>
                 self.emitter.emit_start_document(self.sink, version, encoding.unwrap_or("UTF-8"), standalone),
             XmlEvent::ProcessingInstruction { name, data } =>
                 self.emitter.emit_processing_instruction(self.sink, name, data),
             XmlEvent::StartElement { name, attributes, namespace } =>
                 self.emitter.emit_start_element(self.sink, name, attributes.as_slice(), namespace),
-            XmlEvent::EndElement { name } => 
+            XmlEvent::EndElement { name } =>
                 self.emitter.emit_end_element(self.sink, name),
-            XmlEvent::Comment(content) => 
+            XmlEvent::Comment(content) =>
                 self.emitter.emit_comment(self.sink, content),
-            XmlEvent::CData(content) => 
+            XmlEvent::CData(content) =>
                 self.emitter.emit_cdata(self.sink, content),
-            XmlEvent::Characters(content) => 
+            XmlEvent::Characters(content) =>
                 self.emitter.emit_characters(self.sink, content)
         }
     }


### PR DESCRIPTION
There's really no reason (AFAIK) that the EventWriter needs to claim
ownership of the Writer parameter