### PR TITLE
Fixed compilation error and removed deprecated stuff for rustc 1.0.0-dev (890293655 2015-02-28).

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,6 +1,6 @@
+use std::borrow::Cow;
 use std::borrow::Cow::{Borrowed, Owned};
 use std::iter::IntoIterator;
-use std::string::CowString;
 
 use self::Value::{C, S};
 use self::Process::{B, O};
@@ -46,7 +46,7 @@ impl<'a> Process<'a> {
         }
     }
 
-    fn into_result(self) -> CowString<'a> {
+    fn into_result(self) -> Cow<'a, str> {
         match self {
             B(b) => Borrowed(b),
             O(o) => Owned(o)
@@ -77,7 +77,7 @@ impl<'a> Extend<Value> for Process<'a> {
 /// PCDATA sections.
 ///
 /// Does not perform allocations if the given string does not contain escapable characters.
-pub fn escape_str(s: &str) -> CowString {
+pub fn escape_str(s: &str) -> Cow<str> {
     let mut p = B(s);
     p.extend(s.chars().map(Value::dispatch));
     p.into_result()

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -357,7 +357,7 @@ impl PullParser {
             self.read_prefix_separator = false;
         }
 
-        let invoke_callback = |&: this: &mut PullParser, t| {
+        let invoke_callback = |this: &mut PullParser, t| {
             let name = this.take_buf();
             match name.as_slice().parse() {
                 Ok(name) => on_name(this, t, name),
@@ -1075,7 +1075,7 @@ mod tests {
     );
 
     #[test]
-    fn semicolon_in_attribute_value__issue_3() {
+    fn semicolon_in_attribute_value_issue_3() {
         let (mut r, mut p) = test_data!(r#"
             <a attr="zzz;zzz" />
         "#);

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -1,8 +1,6 @@
 pub use self::emitter::EmitterResult as EventWriterResult;
 pub use self::config::EmitterConfig;
 
-use std::old_io::MemWriter;
-
 use self::emitter::Emitter;
 use self::events::XmlEvent;
 
@@ -49,14 +47,14 @@ impl<W: Writer> EventWriter<W> {
     }
 }
 
-impl EventWriter<MemWriter> {
+impl EventWriter<Vec<u8>> {
     #[inline]
-    pub fn new_into_mem(sink: MemWriter) -> EventWriter<MemWriter> {
+    pub fn new_into_mem(sink: Vec<u8>) -> EventWriter<Vec<u8>> {
         EventWriter::new_into_mem_config(sink, EmitterConfig::new())
     }
 
     #[inline]
-    pub fn new_into_mem_config(sink: MemWriter, config: EmitterConfig) -> EventWriter<MemWriter> {
+    pub fn new_into_mem_config(sink: Vec<u8>, config: EmitterConfig) -> EventWriter<Vec<u8>> {
         EventWriter::new_with_config(sink, config)
     }
 }


### PR DESCRIPTION
I fixed error about obsolete syntax with closure and removed deprecated CowString and MemWriter.