### PR TITLE
Don't specialize on BufReader & Follow standard naming

### DIFF
--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -6,7 +6,6 @@ use std::mem;
 use std::fmt;
 use std::string::ToString;
 use std::io::prelude::*;
-use std::io::BufReader;
 
 use common::{Error, HasPosition, is_whitespace_char, is_name_char};
 
@@ -249,7 +248,7 @@ impl PullLexer {
     /// Returns `None` when logical end of stream is encountered, that is,
     /// after `b.read_char()` returns `None` and the current state is
     /// is exhausted.
-    pub fn next_token<B: Read>(&mut self, b: &mut BufReader<B>) -> Option<LexResult> {
+    pub fn next_token<B: Read>(&mut self, b: &mut B) -> Option<LexResult> {
         // Already reached end of buffer
         if self.eof_handled {
             return None;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -25,12 +25,12 @@ impl<B: Read> EventReader<B> {
     /// Creates a new parser, consuming given stream.
     #[inline]
     pub fn new(source: B) -> EventReader<B> {
-        EventReader::new_with_config(source, ParserConfig::new())
+        EventReader::with_config(source, ParserConfig::new())
     }
 
     /// Creates a new parser with the provded configuration, consuming given `Buffer`.
     #[inline]
-    pub fn new_with_config(source: B, config: ParserConfig) -> EventReader<B> {
+    pub fn with_config(source: B, config: ParserConfig) -> EventReader<B> {
         EventReader { source: source, parser: PullParser::new(config) }
     }
 
@@ -79,7 +79,7 @@ impl<'a, B: Read> Iterator for Events<'a, B> {
 impl<'r> EventReader<&'r [u8]> {
     /// Convenience method to create a reader from a string slice.
     #[inline]
-    pub fn new_from_str_slice(source: &'r str) -> EventReader<&'r [u8]> {
+    pub fn from_str(source: &'r str) -> EventReader<&'r [u8]> {
         EventReader::new(source.as_bytes())
     }
 }
@@ -96,7 +96,7 @@ mod tests {
         let file = File::open(Path::new(path));
         let reader = BufReader::new(file.unwrap());
 
-        let mut eventreader = EventReader::new_with_config(
+        let mut eventreader = EventReader::with_config(
             reader,
             ParserConfig::new()
                 .ignore_comments(true)

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -4,7 +4,6 @@
 //! view for events in XML document.
 
 use std::io::prelude::*;
-use std::io::{BufReader};
 
 use self::parser::PullParser;
 use self::events::XmlEvent;
@@ -18,7 +17,7 @@ pub mod events;
 
 /// Simple wrapper around an `std::io::BufReader` which provides pull-based XML parsing.
 pub struct EventReader<B: Read> {
-    source: BufReader<B>,
+    source: B,
     parser: PullParser
 }
 
@@ -26,12 +25,12 @@ impl<B: Read> EventReader<B> {
     /// Creates a new parser, consuming given stream.
     #[inline]
     pub fn new(source: B) -> EventReader<B> {
-        EventReader::new_with_config(BufReader::new(source), ParserConfig::new())
+        EventReader::new_with_config(source, ParserConfig::new())
     }
 
     /// Creates a new parser with the provded configuration, consuming given `Buffer`.
     #[inline]
-    pub fn new_with_config(source: BufReader<B>, config: ParserConfig) -> EventReader<B> {
+    pub fn new_with_config(source: B, config: ParserConfig) -> EventReader<B> {
         EventReader { source: source, parser: PullParser::new(config) }
     }
 

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -2,7 +2,6 @@
 
 use std::mem;
 use std::io::prelude::*;
-use std::io::BufReader;
 
 use common;
 use common::{Error, XmlVersion, is_name_start_char, is_name_char, is_whitespace_char};
@@ -230,7 +229,7 @@ impl PullParser {
     ///
     /// This method should be always called with the same buffer. If you call it
     /// providing different buffers each time, the result will be undefined.
-    pub fn next<B: Read>(&mut self, r: &mut BufReader<B>) -> XmlEvent {
+    pub fn next<B: Read>(&mut self, r: &mut B) -> XmlEvent {
         if self.finish_event.is_some() {
             return self.finish_event.as_ref().unwrap().clone();
         }


### PR DESCRIPTION
1) Don't hard wire BufReader when not necessary -- the choice of the implementation should be left up to the client
2) Change constructor names to align with rust standard naming scheme