### PR TITLE
Rustup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml-rs"
-version = "0.1.22"
+version = "0.1.23"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT"
 description = "An XML library in pure Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,9 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![forbid(non_camel_case_types)]
-#![feature(io, core)]
+#![feature(io)]
 
 //! This crate currently provides almost XML 1.0/1.1-compliant pull parser.
-
-extern crate core;
 
 #[macro_use]
 extern crate bitflags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![forbid(non_camel_case_types)]
-#![feature(io)]
 
 //! This crate currently provides almost XML 1.0/1.1-compliant pull parser.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![forbid(non_camel_case_types)]
-#![feature(io, core, into_cow)]
+#![feature(io, core)]
 
 //! This crate currently provides almost XML 1.0/1.1-compliant pull parser.
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
-use std::borrow::{IntoCow, ToOwned};
+use std::borrow::{Cow, ToOwned};
 
 use util::OptionBorrowExt;
 
@@ -122,9 +122,9 @@ impl OwnedName {
 
     /// Returns a new `OwnedName` instance representing a plain local name.
     #[inline]
-    pub fn local<'s, S: IntoCow<'s, str>>(local_name: S) -> OwnedName {
+    pub fn local<'s, S: Into<Cow<'s, str>>>(local_name: S) -> OwnedName {
         OwnedName {
-            local_name: local_name.into_cow().into_owned(),
+            local_name: local_name.into().into_owned(),
             namespace: None,
             prefix: None,
         }
@@ -135,13 +135,13 @@ impl OwnedName {
     #[inline]
     pub fn qualified<'s1, 's2, 's3, S1, S2, S3>(local_name: S1, namespace: S2,
                                                 prefix: Option<S3>) -> OwnedName
-            where S1: IntoCow<'s1, str>,
-                  S2: IntoCow<'s2, str>,
-                  S3: IntoCow<'s3, str> {
+            where S1: Into<Cow<'s1, str>>,
+                  S2: Into<Cow<'s2, str>>,
+                  S3: Into<Cow<'s3, str>> {
         OwnedName {
-            local_name: local_name.into_cow().into_owned(),
-            namespace: Some(namespace.into_cow().into_owned()),
-            prefix: prefix.map(|v| v.into_cow().into_owned())
+            local_name: local_name.into().into_owned(),
+            namespace: Some(namespace.into().into_owned()),
+            prefix: prefix.map(|v| v.into().into_owned())
         }
     }
 

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,4 +1,4 @@
-use std::borrow::IntoCow;
+use std::borrow::Cow;
 use std::iter::Rev;
 use std::collections::hash_map::{HashMap, Entry};
 use std::collections::hash_map::Iter as Entries;
@@ -71,11 +71,11 @@ impl Namespace {
     /// `true` if `prefix` has been inserted successfully; `false` if the `prefix`
     /// was already present in the namespace.
     pub fn put<'s1, 's2, S1, S2>(&mut self, prefix: Option<S1>, uri: S2) -> bool
-            where S1: IntoCow<'s1, str>, S2: IntoCow<'s2, str> {
-        match self.0.entry(prefix.map(|v| v.into_cow().into_owned())) {
+            where S1: Into<Cow<'s1, str>>, S2: Into<Cow<'s2, str>> {
+        match self.0.entry(prefix.map(|v| v.into().into_owned())) {
             Entry::Occupied(_) => false,
             Entry::Vacant(ve) => {
-                ve.insert(uri.into_cow().into_owned());
+                ve.insert(uri.into().into_owned());
                 true
             }
         }
@@ -95,8 +95,8 @@ impl Namespace {
     /// `Some(uri)` with `uri` being a previous URI assigned to the `prefix`, or
     /// `None` if such prefix was not present in the namespace before.
     pub fn force_put<'s1, 's2, S1, S2>(&mut self, prefix: Option<S1>, uri: S2) -> Option<String>
-            where S1: IntoCow<'s1, str>, S2: IntoCow<'s2, str> {
-        self.0.insert(prefix.map(|v| v.into_cow().into_owned()), uri.into_cow().into_owned())
+            where S1: Into<Cow<'s1, str>>, S2: Into<Cow<'s2, str>> {
+        self.0.insert(prefix.map(|v| v.into().into_owned()), uri.into().into_owned())
     }
 
     /// Queries the namespace for the given prefix.

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -3,7 +3,7 @@ use std::iter::Rev;
 use std::collections::hash_map::{HashMap, Entry};
 use std::collections::hash_map::Iter as Entries;
 use std::collections::HashSet;
-use core::slice::Iter;
+use std::slice::Iter;
 
 use util::{OptionBorrowExt, IteratorClonedPairwiseExt};
 

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -148,17 +148,17 @@ enum State {
     Normal
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum ClosingSubstate {
     First, Second
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum DoctypeStartedSubstate {
     D, DO, DOC, DOCT, DOCTY, DOCTYP
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum CDataStartedSubstate {
     E, C, CD, CDA, CDAT, CDATA
 }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -979,7 +979,6 @@ impl PullParser {
 
     fn inside_reference(&mut self, t: Token, prev_st: State) -> Option<XmlEvent> {
         use std::char;
-        use std::num::from_str_radix;
 
         match t {
             Token::Character(c) if !self.data.ref_data.is_empty() && is_name_char(c) ||
@@ -1004,7 +1003,7 @@ impl PullParser {
                         if num_str == "0" {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
-                            match from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
+                            match u32::from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
                                 Some(c) => Ok(c),
                                 None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
                             }
@@ -1015,7 +1014,7 @@ impl PullParser {
                         if num_str == "0" {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
-                            match from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
+                            match u32::from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
                                 Some(c) => Ok(c),
                                 None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
                             }

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -141,7 +141,7 @@ enum QualifiedNameTarget {
     ClosingTagNameTarget
 }
 
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum QuoteToken {
     SingleQuoteToken,
     DoubleQuoteToken


### PR DESCRIPTION
I had to more or less reimplement `Read::chars()` myself in order to remove the "io" feature.

This should make this crate compatible with 1.0 beta.