### PR TITLE
Attempt to remove memory allocation

### DIFF
--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -297,7 +297,7 @@ impl PullLexer {
                         None => {
                             // Should never get there, because the string
                             // contains exactly one code point.
-                            continue;
+                            unreachable!();
                         }
                     }
                 },


### PR DESCRIPTION
In the lexer, a buffer is allocated each time a code point has to be read. Reusing the same buffer represents a small optimization (though it could be removed with any refactoring of the parser). On my machine, I can run the parsing loop at 6.5MB/s instead of 5.4MB/s.

I hope that I did not break anything.