### PR TITLE
Removed calls to the slow `token.to_string()`

### DIFF
--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -104,6 +104,22 @@ impl Token {
             _                                 => None
         }
     }
+    
+    // using String.push_str(token.to_string()) is simply way too slow
+    pub fn push_to_string(&self, target: &mut String) {
+        match self.as_static_str() {
+            Some(s) => { target.push_str(s); }
+            None => {
+                match *self {
+                    Token::Chunk(s) => { target.push_str(s); }
+                    Token::Character(c) | Token::Whitespace(c) => {
+                        target.push(c);
+                    }
+                    _ => unreachable!()
+                }
+            }
+        }
+    }
 
     /// Returns `true` if this token contains data that can be interpreted
     /// as a part of the text. Surprisingly, this also means '>' and '=' and '"' and "'".

--- a/src/reader/parser/inside_cdata.rs
+++ b/src/reader/parser/inside_cdata.rs
@@ -17,11 +17,15 @@ impl PullParser {
                 self.into_state(State::OutsideTag, event)
             }
 
-            Token::Whitespace(_) => self.append_str_continue(&t.to_string()),
+            Token::Whitespace(_) => {
+                t.push_to_string(&mut self.buf);
+                None
+            }
 
             _ => {
                 self.inside_whitespace = false;
-                self.append_str_continue(&t.to_string())
+                t.push_to_string(&mut self.buf);
+                None
             }
         }
     }

--- a/src/reader/parser/inside_comment.rs
+++ b/src/reader/parser/inside_comment.rs
@@ -22,7 +22,10 @@ impl PullParser {
 
             _ if self.config.ignore_comments => None,  // Do not modify buffer if ignoring the comment
 
-            _ => self.append_str_continue(&t.to_string()),
+            _ => {
+                t.push_to_string(&mut self.buf);
+                None
+            }
         }
     }
 

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -352,12 +352,6 @@ impl PullParser {
     }
 
     #[inline]
-    fn append_str_continue(&mut self, s: &str) -> Option<XmlEvent> {
-        self.buf.push_str(s);
-        None
-    }
-
-    #[inline]
     fn into_state(&mut self, st: State, ev: Option<XmlEvent>) -> Option<XmlEvent> {
         self.st = st;
         ev
@@ -440,7 +434,10 @@ impl PullParser {
                     let value = self.take_buf();
                     on_value(self, value)
                 }
-                _ => self.append_str_continue(&t.to_string()),
+                _ => {
+                    t.push_to_string(&mut self.buf);
+                    None
+                }
             },
 
             Token::ReferenceStart => {
@@ -452,7 +449,10 @@ impl PullParser {
                 Some(self_error!(self; "Unexpected token inside attribute value: <")),
 
             // Every character except " and ' and < is okay
-            _  => self.append_str_continue(&t.to_string()),
+            _  => {
+                t.push_to_string(&mut self.buf);
+                None
+            }
         }
     }
 

--- a/src/reader/parser/outside_tag.rs
+++ b/src/reader/parser/outside_tag.rs
@@ -33,12 +33,14 @@ impl PullParser {
                     self.push_pos();
                 }
                 self.inside_whitespace = false;
-                self.append_str_continue(&t.to_string())
+                t.push_to_string(&mut self.buf);
+                None
             }
 
             Token::ReferenceEnd => { // Semi-colon in a text outside an entity
                 self.inside_whitespace = false;
-                self.append_str_continue(Token::ReferenceEnd.as_static_str().unwrap())
+                Token::ReferenceEnd.push_to_string(&mut self.buf);
+                None
             }
 
             Token::CommentStart if self.config.coalesce_characters && self.config.ignore_comments => {


### PR DESCRIPTION
I was using `xml-rs` to parse a fairly large amount of XML data, but ran into some serious performance issues. While it took Go's `encoding/xml` about 3 mins to parse all of my data, my Rust version took over 20 mins before I had to stop it.

Profiling the code, I found, that the only real bottleneck was `Token`s being reverted to strings with `to_string` (through `fmt::Display`) in most calls to `append_str_continue` (called a lot by methods called by `dispatch_event`). These calls use the whole `fmt` infrastructure, then allocate a `String`, just to borrow it and push it unto another `String`. I added a method `push_to_string` for `Token` that does this with no allocations/formatting, and replaced `append_str_continue` and calls to it with this.

I mainly patched this for my own use, but I open this PR in case you are interested. :)