### PR TITLE
Implementors of IteratorClonedPairwiseExt must implement Sized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml-rs"
-version = "0.1.25"
+version = "0.1.26"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT"
 description = "An XML library in pure Rust"

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,7 @@ impl<T: ?Sized, U> OptionBorrowExt<T> for Option<U> where U: Borrow<T> {
     }
 }
 
-pub trait IteratorClonedPairwiseExt {
+pub trait IteratorClonedPairwiseExt: Sized {
     fn cloned_pairwise(self) -> ClonedPairwise<Self>;
 }
 


### PR DESCRIPTION
This fixes warnings future warnings, but those warnings are about things that should not be valid and it compiles on stable, unless someone was trying to doing something bogus.