### PR TITLE
Make EmitterError nameable

### DIFF
--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -1,4 +1,5 @@
 pub use self::emitter::EmitterResult as EventWriterResult;
+pub use self::emitter::EmitterError as EventWriterError;
 pub use self::config::EmitterConfig;
 
 use self::emitter::Emitter;


### PR DESCRIPTION
Previously it couldn't be named as it was in a private module