### PR TITLE
Non-namespaced attributes seem to inherit default namespace

### DIFF
--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -470,10 +470,13 @@ impl PullParser {
 
         // check and fix accumulated attributes prefixes
         for attr in attributes.iter_mut() {
-            match self.nst.get(attr.name.borrow().prefix_repr()) {
-                Some("") => attr.name.namespace = None,  // default namespace
-                Some(ns) => attr.name.namespace = Some(ns.into()),
-                None => return Some(self_error!(self; "Attribute {} prefix is unbound", attr.name))
+            for pfx in attr.name.prefix.iter() {
+                let new_ns = match self.nst.get(pfx) {
+                    Some("") => None,  // default namespace
+                    Some(ns) => Some(ns.into()),
+                    None => return Some(self_error!(self; "Attribute {} prefix is unbound", attr.name))
+                };
+                attr.name.namespace = new_ns;
             }
         }
 

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -470,7 +470,7 @@ impl PullParser {
 
         // check and fix accumulated attributes prefixes
         for attr in attributes.iter_mut() {
-            for pfx in attr.name.prefix.iter() {
+            if let Some(ref pfx) = attr.name.prefix {
                 let new_ns = match self.nst.get(pfx) {
                     Some("") => None,  // default namespace
                     Some(ns) => Some(ns.into()),

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -288,6 +288,22 @@ fn issue_105_unexpected_double_dash() {
     );
 }
 
+#[test]
+fn issue_attribues_have_no_default_namespace () {
+    test(
+        br#"<hello xmlns="urn:foo" x="y"/>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement({urn:foo}hello [x="y"])
+            |EndElement({urn:foo}hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false
+    );
+}
+
+
 static START: Once = ONCE_INIT;
 static mut PRINT: bool = false;
 


### PR DESCRIPTION
From http://www.w3.org/TR/REC-xml-names/#defaulting
> The namespace name for an unprefixed attribute name always has no value.

However, I find that `OwnedAttribute` instances from the `EventReader` end up inheriting the default namespace, which I don't think is entirely right. This pull request should fix that.

Thanks,