### PR TITLE
Issue #106: Fix I/O error handling in lexer and parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,3 @@ pub mod escape;
 pub mod namespace;
 pub mod reader;
 pub mod writer;
-mod util;

--- a/src/reader/impl_error.rs
+++ b/src/reader/impl_error.rs
@@ -19,6 +19,7 @@ impl Error {
             kind: kind,
         }
     }
+    pub fn kind(&self) -> &ErrorKind { &self.kind }
 }
 
 impl fmt::Display for Error {

--- a/src/reader/impl_error.rs
+++ b/src/reader/impl_error.rs
@@ -1,0 +1,81 @@
+
+use std::error;
+use std::fmt;
+
+use super::util;
+use common::{Position, TextPosition};
+use super::{Error, ErrorKind};
+
+impl Error {
+    pub fn new( kind: ErrorKind ) -> Self {
+        Error {
+            pos: TextPosition::new(),
+            kind: kind,
+        }
+    }
+    pub fn new_with_pos( pos: TextPosition, kind: ErrorKind ) -> Self {
+        Error {
+            pos: pos,
+            kind: kind,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+       write!(f, "{} {}", self.position(), self.msg())
+    }
+}
+
+impl Position for Error {
+    #[inline]
+    fn position(&self) -> TextPosition { self.pos }
+}
+
+impl Error {
+    /// Returns a reference to a message which is contained inside this error.
+    #[inline]
+    pub fn msg(&self) -> &str {
+        use super::ErrorKind::*;
+        use std::error::Error;
+        match self.kind {
+            UnexpectedEof => "Unexpected end of stream",
+            Utf8( ref e ) => e.description(),
+            Syntax( ref s ) => s.as_ref(),
+            Io( ref e ) => e.description(),
+        }
+    }
+}
+
+impl error::Error for Error {
+    #[inline]
+    fn description(&self) -> &str { self.msg() }
+    fn cause( &self ) -> Option<&error::Error> { None }
+}
+
+
+
+impl Clone for ErrorKind {
+    fn clone( &self ) -> Self {
+        use super::ErrorKind::*;
+        match *self {
+            UnexpectedEof => UnexpectedEof,
+            Utf8( ref e ) => Utf8( e.clone() ),
+            Syntax( ref e ) => Syntax( e.clone() ),
+            Io( ref e ) => Io( util::clone_io_error( e ) ),
+        }
+    }
+}
+impl PartialEq for ErrorKind {
+    fn eq( &self, other: &ErrorKind ) -> bool {
+        use super::ErrorKind::*;
+        match ( self, other ) {
+            ( &UnexpectedEof, &UnexpectedEof ) => true,
+            ( &Utf8( ref left ), &Utf8( ref right ) ) => left == right,
+            ( &Syntax( ref left ), &Syntax( ref right ) ) => left == right,
+            ( &Io( ref left ), &Io( ref right ) ) => left.kind() == right.kind(),
+            ( _, _ ) => false,
+        }
+    }
+}
+impl Eq for ErrorKind {}

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -13,7 +13,7 @@ use name::OwnedName;
 use attribute::OwnedAttribute;
 use namespace::NamespaceStack;
 
-use reader::Error;
+use reader::{Error, ErrorKind};
 use reader::events::XmlEvent;
 use reader::config::ParserConfig;
 use reader::lexer::{Lexer, Token};
@@ -254,7 +254,7 @@ impl PullParser {
             self.nst.pop();
         }
 
-        while let Some(t) = self.lexer.next_token(r) {
+        while let Some(t) = try!(self.lexer.next_token(r)) {
             match t {
                 Ok(t) => match self.dispatch_token(t) {
                     Some(ev) => {
@@ -300,7 +300,12 @@ impl PullParser {
 
     #[inline]
     fn error<M: Into<Cow<'static, str>>>(&self, msg: M) -> Result {
-        Err(Error::new(&self.lexer, msg))
+        Err(
+            Error::new_with_pos(
+                self.lexer.position(),
+                ErrorKind::Syntax( msg.into() )
+            )
+        )
     }
 
     #[inline]


### PR DESCRIPTION
    * moved `::util` to `::reader::util` -- there was nothing there but reading from the io::Read;
    * `impl Into<::reader::Error> for ::util::CharReadError`;
    * `::reader:lexer::Lexer::next_token( ... )` return type changed from `LexStep` to ::reader::Result<LexStep>;
    * exposed `EventReader<R>`'s souce as mut- and immut-reference: I need to feed my Buffer (:io::Read) somehow.
        ( Probably the better solution would be to pub-use PullParser in xml::reader, but it has too many private types in the API signatures )