### PR TITLE
Issue #106: Fix I/O error handling in lexer and parser (attempt #3)

### DIFF
--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -40,16 +40,16 @@ impl Error {
     /// Returns a reference to a message which is contained inside this error.
     #[inline]
     pub fn msg(&self) -> &str {
-    	use self::ErrorKind::*;
-    	match self.kind {
-    		UnexpectedEof => &"Unexpected EOF",
-    		Utf8(ref reason) => error_description(reason),
-    		Io(ref io_error) => error_description(io_error),
-    		Syntax(ref msg) => msg.as_ref(),
-    	}
+        use self::ErrorKind::*;
+        match self.kind {
+            UnexpectedEof => &"Unexpected EOF",
+            Utf8(ref reason) => error_description(reason),
+            Io(ref io_error) => error_description(io_error),
+            Syntax(ref msg) => msg.as_ref(),
+        }
     }
 
-    pub fn kind( &self ) -> &ErrorKind { &self.kind }
+    pub fn kind(&self) -> &ErrorKind { &self.kind }
 }
 
 impl error::Error for Error {
@@ -57,61 +57,61 @@ impl error::Error for Error {
     fn description(&self) -> &str { self.msg() }
 }
 
-impl<'a, P, M> From<( &'a P, M )> for Error where P: Position, M: Into<Cow<'static, str>> {
-	fn from(orig: (&'a P, M)) -> Self {
-		Error{
-			pos: orig.0.position(),
-			kind: ErrorKind::Syntax(orig.1.into())
-		}
-	}
+impl<'a, P, M> From<(&'a P, M)> for Error where P: Position, M: Into<Cow<'static, str>> {
+    fn from(orig: (&'a P, M)) -> Self {
+        Error{
+            pos: orig.0.position(),
+            kind: ErrorKind::Syntax(orig.1.into())
+        }
+    }
 }
 
 impl From<util::CharReadError> for Error {
-	fn from(e: util::CharReadError) -> Self {
-		use util::CharReadError::*;
-		Error{
-			pos: TextPosition::new(),
-			kind: match e {
-				UnexpectedEof => ErrorKind::UnexpectedEof,
-				Utf8(ref reason) => ErrorKind::Utf8(reason.clone()),
-				Io(ref io_error) =>
-					ErrorKind::Io(
-						io::Error::new(
-							io_error.kind(),
-							error_description(io_error)
-						)
-					),
-			}
-		}
-	}
+    fn from(e: util::CharReadError) -> Self {
+        use util::CharReadError::*;
+        Error{
+            pos: TextPosition::new(),
+            kind: match e {
+                UnexpectedEof => ErrorKind::UnexpectedEof,
+                Utf8(ref reason) => ErrorKind::Utf8(reason.clone()),
+                Io(ref io_error) =>
+                    ErrorKind::Io(
+                        io::Error::new(
+                            io_error.kind(),
+                            error_description(io_error)
+                        )
+                    ),
+            }
+        }
+    }
 }
 
 impl Clone for ErrorKind {
-	fn clone( &self ) -> Self {
-		use self::ErrorKind::*;
-		match *self {
-			UnexpectedEof => UnexpectedEof,
-			Utf8(ref reason) => Utf8(reason.clone()),
-			Io(ref io_error) => Io(io::Error::new(io_error.kind(), error_description(io_error))),
-			Syntax(ref msg) => Syntax(msg.clone()),
-		}
-	}
+    fn clone(&self) -> Self {
+        use self::ErrorKind::*;
+        match *self {
+            UnexpectedEof => UnexpectedEof,
+            Utf8(ref reason) => Utf8(reason.clone()),
+            Io(ref io_error) => Io(io::Error::new(io_error.kind(), error_description(io_error))),
+            Syntax(ref msg) => Syntax(msg.clone()),
+        }
+    }
 }
 impl PartialEq for ErrorKind {
-	fn eq( &self, other: &ErrorKind ) -> bool {
-		use self::ErrorKind::*;
-		match (self, other) {
-			(&UnexpectedEof, &UnexpectedEof) => true,
-			(&Utf8(ref left), &Utf8(ref right)) => left == right,
-			(&Io(ref left), &Io(ref right)) =>
-				left.kind() == right.kind() &&
-				error_description(left) == error_description(right),
-			(&Syntax(ref left), &Syntax(ref right)) =>
-				left == right,
+    fn eq(&self, other: &ErrorKind) -> bool {
+        use self::ErrorKind::*;
+        match (self, other) {
+            (&UnexpectedEof, &UnexpectedEof) => true,
+            (&Utf8(ref left), &Utf8(ref right)) => left == right,
+            (&Io(ref left), &Io(ref right)) =>
+                left.kind() == right.kind() &&
+                error_description(left) == error_description(right),
+            (&Syntax(ref left), &Syntax(ref right)) =>
+                left == right,
 
-			(_, _) => false,
-		}
-	}
+            (_, _) => false,
+        }
+    }
 }
 impl Eq for ErrorKind {}
 

--- a/src/reader/error_impl.rs
+++ b/src/reader/error_impl.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::error;
 
+use util;
 use common::{Position, TextPosition};
 
 use super::{Error, ErrorKind};
@@ -49,9 +50,9 @@ impl<'a, P, M> From<( &'a P, M )> for Error where P: Position, M: Into<Cow<'stat
 	}
 }
 
-impl From<::util::CharReadError> for Error {
-	fn from( e: ::util::CharReadError ) -> Self {
-		use ::util::CharReadError::*;
+impl From<util::CharReadError> for Error {
+	fn from( e: util::CharReadError ) -> Self {
+		use util::CharReadError::*;
 		Error{
 			pos: TextPosition::new(),
 			kind: match e {

--- a/src/reader/error_impl.rs
+++ b/src/reader/error_impl.rs
@@ -27,9 +27,9 @@ impl Error {
     	use super::ErrorKind::*;
     	match self.kind {
     		UnexpectedEof => &"Unexpected EOF",
-    		Utf8( ref reason ) => error_description( reason ),
-    		Io( ref io_error ) => error_description( io_error ),
-    		Syntax( ref msg ) => msg.as_ref(),
+    		Utf8(ref reason) => error_description(reason),
+    		Io(ref io_error) => error_description(io_error),
+    		Syntax(ref msg) => msg.as_ref(),
     	}
     }
 
@@ -42,27 +42,27 @@ impl error::Error for Error {
 }
 
 impl<'a, P, M> From<( &'a P, M )> for Error where P: Position, M: Into<Cow<'static, str>> {
-	fn from( orig: (&'a P, M) ) -> Self {
+	fn from(orig: (&'a P, M)) -> Self {
 		Error{
 			pos: orig.0.position(),
-			kind: ErrorKind::Syntax( orig.1.into() )
+			kind: ErrorKind::Syntax(orig.1.into())
 		}
 	}
 }
 
 impl From<util::CharReadError> for Error {
-	fn from( e: util::CharReadError ) -> Self {
+	fn from(e: util::CharReadError) -> Self {
 		use util::CharReadError::*;
 		Error{
 			pos: TextPosition::new(),
 			kind: match e {
 				UnexpectedEof => ErrorKind::UnexpectedEof,
-				Utf8( ref reason ) => ErrorKind::Utf8( reason.clone() ),
-				Io( ref io_error ) =>
+				Utf8(ref reason) => ErrorKind::Utf8(reason.clone()),
+				Io(ref io_error) =>
 					ErrorKind::Io(
 						io::Error::new(
 							io_error.kind(),
-							error_description( io_error )
+							error_description(io_error)
 						)
 					),
 			}
@@ -75,28 +75,28 @@ impl Clone for ErrorKind {
 		use super::ErrorKind::*;
 		match *self {
 			UnexpectedEof => UnexpectedEof,
-			Utf8( ref reason ) => Utf8( reason.clone() ),
-			Io( ref io_error ) => Io( io::Error::new( io_error.kind(), error_description( io_error ) ) ),
-			Syntax( ref msg ) => Syntax( msg.clone() ),
+			Utf8(ref reason) => Utf8(reason.clone()),
+			Io(ref io_error) => Io(io::Error::new(io_error.kind(), error_description(io_error))),
+			Syntax(ref msg) => Syntax(msg.clone()),
 		}
 	}
 }
 impl PartialEq for ErrorKind {
 	fn eq( &self, other: &ErrorKind ) -> bool {
 		use super::ErrorKind::*;
-		match ( self, other ) {
-			( &UnexpectedEof, &UnexpectedEof ) => true,
-			( &Utf8( ref left ), &Utf8( ref right ) ) => left == right,
-			( &Io( ref left ), &Io( ref right ) ) =>
+		match (self, other) {
+			(&UnexpectedEof, &UnexpectedEof) => true,
+			(&Utf8(ref left), &Utf8(ref right)) => left == right,
+			(&Io(ref left), &Io(ref right)) =>
 				left.kind() == right.kind() &&
-				error_description( left ) == error_description( right ),
-			( &Syntax( ref left ), &Syntax( ref right ) ) =>
+				error_description(left) == error_description(right),
+			(&Syntax(ref left), &Syntax(ref right)) =>
 				left == right,
 
-			( _, _ ) => false,
+			(_, _) => false,
 		}
 	}
 }
 impl Eq for ErrorKind {}
 
-fn error_description( e: &error::Error ) -> &str { e.description() }
+fn error_description(e: &error::Error) -> &str { e.description() }

--- a/src/reader/error_impl.rs
+++ b/src/reader/error_impl.rs
@@ -1,0 +1,106 @@
+
+use std::io;
+use std::borrow::Cow;
+use std::fmt;
+use std::error;
+
+use common::{Position, TextPosition};
+
+use super::{Error, ErrorKind};
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.pos, self.msg())
+    }
+}
+
+impl Position for Error {
+    #[inline]
+    fn position(&self) -> TextPosition { self.pos }
+}
+
+impl Error {
+    // /// Creates a new error using position information from the provided
+    // /// `Position` object and a message.
+    // #[inline]
+    // pub fn new<O: Position, S: Into<Cow<'static, str>>>(o: &O, msg: S) -> Error {
+    //     Error { pos: o.position(), msg: msg.into() }
+    // }
+
+    /// Returns a reference to a message which is contained inside this error.
+    #[inline]
+    pub fn msg(&self) -> &str {
+    	use super::ErrorKind::*;
+    	match self.kind {
+    		UnexpectedEof => &"Unexpected EOF",
+    		Utf8( ref reason ) => error_description( reason ),
+    		Io( ref io_error ) => error_description( io_error ),
+    		Syntax( ref msg ) => msg.as_ref(),
+    	}
+    }
+}
+
+impl error::Error for Error {
+    #[inline]
+    fn description(&self) -> &str { self.msg() }
+}
+
+impl<'a, P, M> From<( &'a P, M )> for Error where P: Position, M: Into<Cow<'static, str>> {
+	fn from( orig: (&'a P, M) ) -> Self {
+		Error{
+			pos: orig.0.position(),
+			kind: ErrorKind::Syntax( orig.1.into() )
+		}
+	}
+}
+
+impl From<::util::CharReadError> for Error {
+	fn from( e: ::util::CharReadError ) -> Self {
+		use ::util::CharReadError::*;
+		Error{
+			pos: TextPosition::new(),
+			kind: match e {
+				UnexpectedEof => ErrorKind::UnexpectedEof,
+				Utf8( ref reason ) => ErrorKind::Utf8( reason.clone() ),
+				Io( ref io_error ) =>
+					ErrorKind::Io(
+						io::Error::new(
+							io_error.kind(),
+							error_description( io_error )
+						)
+					),
+			}
+		}
+	}
+}
+
+impl Clone for ErrorKind {
+	fn clone( &self ) -> Self {
+		use super::ErrorKind::*;
+		match *self {
+			UnexpectedEof => UnexpectedEof,
+			Utf8( ref reason ) => Utf8( reason.clone() ),
+			Io( ref io_error ) => Io( io::Error::new( io_error.kind(), error_description( io_error ) ) ),
+			Syntax( ref msg ) => Syntax( msg.clone() ),
+		}
+	}
+}
+impl PartialEq for ErrorKind {
+	fn eq( &self, other: &ErrorKind ) -> bool {
+		use super::ErrorKind::*;
+		match ( self, other ) {
+			( &UnexpectedEof, &UnexpectedEof ) => true,
+			( &Utf8( ref left ), &Utf8( ref right ) ) => left == right,
+			( &Io( ref left ), &Io( ref right ) ) =>
+				left.kind() == right.kind() &&
+				error_description( left ) == error_description( right ),
+			( &Syntax( ref left ), &Syntax( ref right ) ) =>
+				left == right,
+
+			( _, _ ) => false,
+		}
+	}
+}
+impl Eq for ErrorKind {}
+
+fn error_description( e: &error::Error ) -> &str { e.description() }

--- a/src/reader/error_impl.rs
+++ b/src/reader/error_impl.rs
@@ -20,13 +20,6 @@ impl Position for Error {
 }
 
 impl Error {
-    // /// Creates a new error using position information from the provided
-    // /// `Position` object and a message.
-    // #[inline]
-    // pub fn new<O: Position, S: Into<Cow<'static, str>>>(o: &O, msg: S) -> Error {
-    //     Error { pos: o.position(), msg: msg.into() }
-    // }
-
     /// Returns a reference to a message which is contained inside this error.
     #[inline]
     pub fn msg(&self) -> &str {
@@ -38,6 +31,8 @@ impl Error {
     		Syntax( ref msg ) => msg.as_ref(),
     	}
     }
+
+    pub fn kind( &self ) -> &ErrorKind { &self.kind }
 }
 
 impl error::Error for Error {

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -270,9 +270,9 @@ impl Lexer {
     /// this method is called, but the resulting behavior is undefined in this case.
     ///
     /// Return value:
-    /// * `Err( reason ) where reason: reader::Error` - when an error occurs;
-    /// * `Ok( None )` - upon end of stream is reached;
-    /// * `Ok( Some( token ) ) where token: Token` - in case a complete-token has been read from the stream.
+    /// * `Err(reason) where reason: reader::Error` - when an error occurs;
+    /// * `Ok(None)` - upon end of stream is reached;
+    /// * `Ok(Some(token)) where token: Token` - in case a complete-token has been read from the stream.
     pub fn next_token<B: Read>(&mut self, b: &mut B) -> Result {
         // Already reached end of buffer
         if self.eof_handled {

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -181,8 +181,7 @@ enum CDataStartedSubstate {
 }
 
 /// `Result` represents lexing result. It is either a token or an error message.
-pub type Result = result::Result<Token, Error>;
-type LexStep = Option<Result>;  // TODO: make up with better name
+pub type Result = result::Result<Option<Token>, Error>;
 
 /// Helps to set up a dispatch table for lexing large unambigous tokens like
 /// `<![CDATA[` or `<!DOCTYPE `.
@@ -270,13 +269,14 @@ impl Lexer {
     /// It is possible to pass different instaces of `BufReader` each time
     /// this method is called, but the resulting behavior is undefined in this case.
     ///
-    /// Returns `None` when a logical end of stream is encountered, that is,
-    /// after `b.read_char()` returns `None` and the current state is
-    /// is exhausted.
-    pub fn next_token<B: Read>(&mut self, b: &mut B) -> LexStep {
+    /// Return value:
+    /// * Err( reason ) where reason: reader::Error - when an error occurs;
+    /// * Ok( None ) - upon end of stream is reached;
+    /// * Ok( Some( token: Token ) ) - in case a complete-token has been read from the stream.
+    pub fn next_token<B: Read>(&mut self, b: &mut B) -> Result {
         // Already reached end of buffer
         if self.eof_handled {
-            return None;
+            return Ok(None);
         }
 
         if !self.inside_token {
@@ -286,10 +286,10 @@ impl Lexer {
 
         // Check if we have saved a char or two for ourselves
         while let Some(c) = self.char_queue.pop_front() {
-            match self.read_next_token(c) {
+            match try!(self.read_next_token(c)) {
                 Some(t) => {
                     self.inside_token = false;
-                    return Some(t);
+                    return Ok(Some(t));
                 }
                 None => {}  // continue
             }
@@ -303,10 +303,10 @@ impl Lexer {
                 Err(_) => break     // FIXME: errors should be handled properly
             };
 
-            match self.read_next_token(c) {
+            match try!(self.read_next_token(c)) {
                 Some(t) => {
                     self.inside_token = false;
-                    return Some(t);
+                    return Ok(Some(t));
                 }
                 None => {
                     // continue
@@ -321,19 +321,19 @@ impl Lexer {
             State::TagStarted | State::CommentOrCDataOrDoctypeStarted |
             State::CommentStarted | State::CDataStarted(_)| State::DoctypeStarted(_) |
             State::CommentClosing(ClosingSubstate::Second)  =>
-                Some(Err(self.error("Unexpected end of stream"))),
+                Err(self.error("Unexpected end of stream")),
             State::ProcessingInstructionClosing =>
-                Some(Ok(Token::Character('?'))),
+                Ok(Some(Token::Character('?'))),
             State::EmptyTagClosing =>
-                Some(Ok(Token::Character('/'))),
+                Ok(Some(Token::Character('/'))),
             State::CommentClosing(ClosingSubstate::First) =>
-                Some(Ok(Token::Character('-'))),
+                Ok(Some(Token::Character('-'))),
             State::CDataClosing(ClosingSubstate::First) =>
-                Some(Ok(Token::Character(']'))),
+                Ok(Some(Token::Character(']'))),
             State::CDataClosing(ClosingSubstate::Second) =>
-                Some(Ok(Token::Chunk("]]"))),
+                Ok(Some(Token::Chunk("]]"))),
             State::Normal =>
-                None
+                Ok(None)
         }
     }
 
@@ -343,7 +343,7 @@ impl Lexer {
     }
 
     #[inline]
-    fn read_next_token(&mut self, c: char) -> LexStep {
+    fn read_next_token(&mut self, c: char) -> Result {
         let res = self.dispatch_char(c);
         if self.char_queue.is_empty() {
             if c == '\n' {
@@ -355,7 +355,7 @@ impl Lexer {
         res
     }
 
-    fn dispatch_char(&mut self, c: char) -> LexStep {
+    fn dispatch_char(&mut self, c: char) -> Result {
         match self.st {
             State::Normal                         => self.normal(c),
             State::TagStarted                     => self.tag_opened(c),
@@ -371,53 +371,53 @@ impl Lexer {
     }
 
     #[inline]
-    fn move_to(&mut self, st: State) -> LexStep {
+    fn move_to(&mut self, st: State) -> Result {
         self.st = st;
-        None
+        Ok(None)
     }
 
     #[inline]
-    fn move_to_with(&mut self, st: State, token: Token) -> LexStep {
+    fn move_to_with(&mut self, st: State, token: Token) -> Result {
         self.st = st;
-        Some(Ok(token))
+        Ok(Some(token))
     }
 
     #[inline]
-    fn move_to_with_unread(&mut self, st: State, cs: &[char], token: Token) -> LexStep {
+    fn move_to_with_unread(&mut self, st: State, cs: &[char], token: Token) -> Result {
         self.char_queue.extend(cs.iter().cloned());
         self.move_to_with(st, token)
     }
 
-    fn handle_error(&mut self, chunk: &'static str, c: char) -> LexStep {
+    fn handle_error(&mut self, chunk: &'static str, c: char) -> Result {
         self.char_queue.push_back(c);
         if self.skip_errors || (self.inside_comment && chunk != "--") {  // FIXME: looks hacky
             self.move_to_with(State::Normal, Token::Chunk(chunk))
         } else {
-            Some(Err(self.error(format!("Unexpected token '{}' before '{}'", chunk, c))))
+            Err(self.error(format!("Unexpected token '{}' before '{}'", chunk, c)))
         }
     }
 
     /// Encountered a char
-    fn normal(&mut self, c: char) -> LexStep {
+    fn normal(&mut self, c: char) -> Result {
         match c {
             '<'                        => self.move_to(State::TagStarted),
-            '>'                        => Some(Ok(Token::TagEnd)),
+            '>'                        => Ok(Some(Token::TagEnd)),
             '/'                        => self.move_to(State::EmptyTagClosing),
-            '='                        => Some(Ok(Token::EqualsSign)),
-            '"'                        => Some(Ok(Token::DoubleQuote)),
-            '\''                       => Some(Ok(Token::SingleQuote)),
+            '='                        => Ok(Some(Token::EqualsSign)),
+            '"'                        => Ok(Some(Token::DoubleQuote)),
+            '\''                       => Ok(Some(Token::SingleQuote)),
             '?'                        => self.move_to(State::ProcessingInstructionClosing),
             '-'                        => self.move_to(State::CommentClosing(ClosingSubstate::First)),
             ']'                        => self.move_to(State::CDataClosing(ClosingSubstate::First)),
-            '&'                        => Some(Ok(Token::ReferenceStart)),
-            ';'                        => Some(Ok(Token::ReferenceEnd)),
-            _ if is_whitespace_char(c) => Some(Ok(Token::Whitespace(c))),
-            _                          => Some(Ok(Token::Character(c)))
+            '&'                        => Ok(Some(Token::ReferenceStart)),
+            ';'                        => Ok(Some(Token::ReferenceEnd)),
+            _ if is_whitespace_char(c) => Ok(Some(Token::Whitespace(c))),
+            _                          => Ok(Some(Token::Character(c)))
         }
     }
 
     /// Encountered '<'
-    fn tag_opened(&mut self, c: char) -> LexStep {
+    fn tag_opened(&mut self, c: char) -> Result {
         match c {
             '?'                        => self.move_to_with(State::Normal, Token::ProcessingInstructionStart),
             '/'                        => self.move_to_with(State::Normal, Token::ClosingTagStart),
@@ -429,7 +429,7 @@ impl Lexer {
     }
 
     /// Encountered '<!'
-    fn comment_or_cdata_or_doctype_started(&mut self, c: char) -> LexStep {
+    fn comment_or_cdata_or_doctype_started(&mut self, c: char) -> Result {
         match c {
             '-' => self.move_to(State::CommentStarted),
             '[' => self.move_to(State::CDataStarted(CDataStartedSubstate::E)),
@@ -439,7 +439,7 @@ impl Lexer {
     }
 
     /// Encountered '<!-'
-    fn comment_started(&mut self, c: char) -> LexStep {
+    fn comment_started(&mut self, c: char) -> Result {
         match c {
             '-' => self.move_to_with(State::Normal, Token::CommentStart),
             _   => self.handle_error("<!-", c)
@@ -447,7 +447,7 @@ impl Lexer {
     }
 
     /// Encountered '<!['
-    fn cdata_started(&mut self, c: char, s: CDataStartedSubstate) -> LexStep {
+    fn cdata_started(&mut self, c: char, s: CDataStartedSubstate) -> Result {
         use self::CDataStartedSubstate::{E, C, CD, CDA, CDAT, CDATA};
         dispatch_on_enum_state!(self, s, c, State::CDataStarted,
             E     ; 'C' ; C     ; "<![",
@@ -460,7 +460,7 @@ impl Lexer {
     }
 
     /// Encountered '<!D'
-    fn doctype_started(&mut self, c: char, s: DoctypeStartedSubstate) -> LexStep {
+    fn doctype_started(&mut self, c: char, s: DoctypeStartedSubstate) -> Result {
         use self::DoctypeStartedSubstate::{D, DO, DOC, DOCT, DOCTY, DOCTYP};
         dispatch_on_enum_state!(self, s, c, State::DoctypeStarted,
             D      ; 'O' ; DO     ; "<!D",
@@ -473,7 +473,7 @@ impl Lexer {
     }
 
     /// Encountered '?'
-    fn processing_instruction_closing(&mut self, c: char) -> LexStep {
+    fn processing_instruction_closing(&mut self, c: char) -> Result {
         match c {
             '>' => self.move_to_with(State::Normal, Token::ProcessingInstructionEnd),
             _   => self.move_to_with_unread(State::Normal, &[c], Token::Character('?')),
@@ -481,7 +481,7 @@ impl Lexer {
     }
 
     /// Encountered '/'
-    fn empty_element_closing(&mut self, c: char) -> LexStep {
+    fn empty_element_closing(&mut self, c: char) -> Result {
         match c {
             '>' => self.move_to_with(State::Normal, Token::EmptyTagEnd),
             _   => self.move_to_with_unread(State::Normal, &[c], Token::Character('/')),
@@ -489,7 +489,7 @@ impl Lexer {
     }
 
     /// Encountered '-'
-    fn comment_closing(&mut self, c: char, s: ClosingSubstate) -> LexStep {
+    fn comment_closing(&mut self, c: char, s: ClosingSubstate) -> Result {
         match s {
             ClosingSubstate::First => match c {
                 '-' => self.move_to(State::CommentClosing(ClosingSubstate::Second)),
@@ -498,18 +498,18 @@ impl Lexer {
             ClosingSubstate::Second => match c {
                 '>'                      => self.move_to_with(State::Normal, Token::CommentEnd),
                 // double dash not followed by a greater-than is a hard error inside comment
-                _ if self.inside_comment => self.handle_error("--", c),  
+                _ if self.inside_comment => self.handle_error("--", c),
                 // nothing else except comment closing starts with a double dash, and comment
                 // closing can never be after another dash, and also we're outside of a comment,
-                // therefore it is safe to push only the last read character to the list of unread 
+                // therefore it is safe to push only the last read character to the list of unread
                 // characters and pass the double dash directly to the output
-                _                        => self.move_to_with_unread(State::Normal, &[c], Token::Chunk("--")) 
+                _                        => self.move_to_with_unread(State::Normal, &[c], Token::Chunk("--"))
             }
         }
     }
 
     /// Encountered ']'
-    fn cdata_closing(&mut self, c: char, s: ClosingSubstate) -> LexStep {
+    fn cdata_closing(&mut self, c: char, s: ClosingSubstate) -> Result {
         match s {
             ClosingSubstate::First => match c {
                 ']' => self.move_to(State::CDataClosing(ClosingSubstate::Second)),
@@ -533,7 +533,7 @@ mod tests {
     macro_rules! assert_oks(
         (for $lex:ident and $buf:ident ; $($e:expr)+) => ({
             $(
-                assert_eq!(Some(Ok($e)), $lex.next_token(&mut $buf));
+                assert_eq!(Ok(Some($e)), $lex.next_token(&mut $buf));
              )+
         })
     );
@@ -541,9 +541,8 @@ mod tests {
     macro_rules! assert_err(
         (for $lex:ident and $buf:ident expect row $r:expr ; $c:expr, $s:expr) => ({
             let err = $lex.next_token(&mut $buf);
-            assert!(err.is_some());
-            assert!(err.as_ref().unwrap().is_err());
-            let err = err.unwrap().unwrap_err();
+            assert!(err.is_err());
+            let err = err.unwrap_err();
             assert_eq!($r as u64, err.position().row);
             assert_eq!($c as u64, err.position().column);
             assert_eq!($s, err.msg());
@@ -552,7 +551,7 @@ mod tests {
 
     macro_rules! assert_none(
         (for $lex:ident and $buf:ident) => (
-            assert_eq!(None, $lex.next_token(&mut $buf));
+            assert_eq!(Ok(None), $lex.next_token(&mut $buf));
         )
     );
 

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -270,9 +270,9 @@ impl Lexer {
     /// this method is called, but the resulting behavior is undefined in this case.
     ///
     /// Return value:
-    /// * Err( reason ) where reason: reader::Error - when an error occurs;
-    /// * Ok( None ) - upon end of stream is reached;
-    /// * Ok( Some( token: Token ) ) - in case a complete-token has been read from the stream.
+    /// * `Err( reason ) where reason: reader::Error` - when an error occurs;
+    /// * `Ok( None )` - upon end of stream is reached;
+    /// * `Ok( Some( token ) ) where token: Token` - in case a complete-token has been read from the stream.
     pub fn next_token<B: Read>(&mut self, b: &mut B) -> Result {
         // Already reached end of buffer
         if self.eof_handled {

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -297,10 +297,9 @@ impl Lexer {
 
         loop {
             // TODO: this should handle multiple encodings
-            let c = match util::next_char_from(b) {
-                Ok(Some(c)) => c,   // got next char
-                Ok(None) => break,  // nothing to read left
-                Err(_) => break     // FIXME: errors should be handled properly
+            let c = match try!(util::next_char_from(b)) {
+                Some(c) => c,   // got next char
+                None => break,  // nothing to read left
             };
 
             match try!(self.read_next_token(c)) {
@@ -339,7 +338,7 @@ impl Lexer {
 
     #[inline]
     fn error<M: Into<Cow<'static, str>>>(&self, msg: M) -> Error {
-        Error::new(self, msg)
+        (self, msg).into()
     }
 
     #[inline]

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -3,10 +3,8 @@
 //! The most important type in this module is `EventReader`, which provides an iterator
 //! view for events in XML document.
 
-use std::io::{self, Read};
-use std::borrow::Cow;
+use std::io::{Read};
 use std::result;
-use std::str;
 
 use common::{Position, TextPosition};
 
@@ -20,24 +18,8 @@ mod parser;
 mod config;
 mod events;
 
-mod error_impl;
-
-#[derive(Debug)]
-pub enum ErrorKind {
-    Syntax(Cow<'static, str>),
-    Io(io::Error),
-    Utf8(str::Utf8Error),
-    UnexpectedEof,
-}
-
-/// An XML parsing error.
-///
-/// Consists of a 2D position in a document and a textual message describing the error.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Error {
-    pos: TextPosition,
-    kind: ErrorKind,
-}
+mod error;
+pub use self::error::{Error, ErrorKind};
 
 /// A result type yielded by `XmlReader`.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -69,6 +69,9 @@ impl<R: Read> EventReader<R> {
     pub fn next(&mut self) -> Result<XmlEvent> {
         self.parser.next(&mut self.source)
     }
+
+    pub fn source( &self ) -> &R { &self.source }
+    pub fn source_mut( &mut self ) -> &mut R { &mut self.source }
 }
 
 impl<B: Read> Position for EventReader<B> {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -52,8 +52,8 @@ impl<R: Read> EventReader<R> {
         self.parser.next(&mut self.source)
     }
 
-    pub fn source( &self ) -> &R { &self.source }
-    pub fn source_mut( &mut self ) -> &mut R { &mut self.source }
+    pub fn source(&self) -> &R { &self.source }
+    pub fn source_mut(&mut self) -> &mut R { &mut self.source }
 }
 
 impl<B: Read> Position for EventReader<B> {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -24,9 +24,9 @@ mod error_impl;
 
 #[derive(Debug)]
 pub enum ErrorKind {
-    Syntax( Cow<'static, str> ),
-    Io( io::Error ),
-    Utf8( str::Utf8Error ),
+    Syntax(Cow<'static, str>),
+    Io(io::Error),
+    Utf8(str::Utf8Error),
     UnexpectedEof,
 }
 

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -299,8 +299,7 @@ impl PullParser {
         } else {
             self_error!(self; "Unexpected end of stream: still inside the root element")
         };
-        self.terminal_result = Some(ev.clone());
-        ev
+        self.set_terminal_result( ev )
     }
 
     // This function is to be called when a terminal event is reached.

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -304,14 +304,14 @@ impl PullParser {
 
     // This function is to be called when a terminal event is reached.
     // The function sets up the `self.final_result` into `Some(result)` and return `result`.
-    fn set_final_result( &mut self, result: Result ) -> Result {
+    fn set_final_result(&mut self, result: Result) -> Result {
         self.final_result = Some(result.clone());
         result
     }
 
     #[inline]
     fn error<M: Into<Cow<'static, str>>>(&self, msg: M) -> Result {
-        Err( (&self.lexer, msg).into() )
+        Err((&self.lexer, msg).into())
     }
 
     #[inline]

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -75,7 +75,7 @@ pub struct PullParser {
     nst: NamespaceStack,
 
     data: MarkupData,
-    terminal_result: Option<Result>,
+    final_result: Option<Result>,
     next_event: Option<Result>,
     est: ElementStack,
     pos: Vec<TextPosition>,
@@ -108,7 +108,7 @@ impl PullParser {
                 attr_name: None,
                 attributes: Vec::new()
             },
-            terminal_result: None,
+            final_result: None,
             next_event: None,
             est: Vec::new(),
             pos: vec![TextPosition::new()],
@@ -240,7 +240,7 @@ impl PullParser {
     /// This method should be always called with the same buffer. If you call it
     /// providing different buffers each time, the result will be undefined.
     pub fn next<R: Read>(&mut self, r: &mut R) -> Result {
-        if let Some(ref ev) = self.terminal_result {
+        if let Some(ref ev) = self.final_result {
             return ev.clone();
         }
 
@@ -266,7 +266,7 @@ impl PullParser {
                                 Some( Ok( XmlEvent::EndDocument ) ) =>
                                     return {
                                         self.next_pos();
-                                        self.set_terminal_result( Ok( XmlEvent::EndDocument ) )
+                                        self.set_final_result( Ok( XmlEvent::EndDocument ) )
                                     },
                                 Some( Ok( xml_event ) ) =>
                                     return {
@@ -276,12 +276,12 @@ impl PullParser {
                                 Some( Err( xml_error ) ) =>
                                     return {
                                         self.next_pos();
-                                        self.set_terminal_result( Err( xml_error ) )
+                                        self.set_final_result( Err( xml_error ) )
                                     },
                             }
                     },
                 Err( lexer_error ) =>
-                    return self.set_terminal_result( Err( lexer_error ) ),
+                    return self.set_final_result( Err( lexer_error ) ),
             }
         }
 
@@ -299,13 +299,13 @@ impl PullParser {
         } else {
             self_error!(self; "Unexpected end of stream: still inside the root element")
         };
-        self.set_terminal_result( ev )
+        self.set_final_result( ev )
     }
 
     // This function is to be called when a terminal event is reached.
-    // The function sets up the `self.terminal_result` into `Some(result)` and return `result`.
-    fn set_terminal_result( &mut self, result: Result ) -> Result {
-        self.terminal_result = Some(result.clone());
+    // The function sets up the `self.final_result` into `Some(result)` and return `result`.
+    fn set_final_result( &mut self, result: Result ) -> Result {
+        self.final_result = Some(result.clone());
         result
     }
 

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -13,7 +13,6 @@ use name::OwnedName;
 use attribute::OwnedAttribute;
 use namespace::NamespaceStack;
 
-use reader::Error;
 use reader::events::XmlEvent;
 use reader::config::ParserConfig;
 use reader::lexer::{Lexer, Token};
@@ -313,7 +312,7 @@ impl PullParser {
 
     #[inline]
     fn error<M: Into<Cow<'static, str>>>(&self, msg: M) -> Result {
-        Err(Error::new(&self.lexer, msg))
+        Err( (&self.lexer, msg).into() )
     }
 
     #[inline]

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -254,34 +254,34 @@ impl PullParser {
         }
 
         loop {
-            // While lexer gives us Ok( maybe_token ) -- we loop.
+            // While lexer gives us Ok(maybe_token) -- we loop.
             // Upon having a complete XML-event -- we return from the whole function.
             match self.lexer.next_token(r) {
-                Ok( maybe_token ) =>
+                Ok(maybe_token) =>
                     match maybe_token {
                         None => break,
-                        Some( token ) =>
-                            match self.dispatch_token( token ) {
+                        Some(token) =>
+                            match self.dispatch_token(token) {
                                 None => {} // continue
-                                Some( Ok( XmlEvent::EndDocument ) ) =>
+                                Some(Ok(XmlEvent::EndDocument)) =>
                                     return {
                                         self.next_pos();
-                                        self.set_final_result( Ok( XmlEvent::EndDocument ) )
+                                        self.set_final_result(Ok(XmlEvent::EndDocument))
                                     },
-                                Some( Ok( xml_event ) ) =>
+                                Some(Ok(xml_event)) =>
                                     return {
                                         self.next_pos();
-                                        Ok( xml_event )
+                                        Ok(xml_event)
                                     },
-                                Some( Err( xml_error ) ) =>
+                                Some(Err(xml_error)) =>
                                     return {
                                         self.next_pos();
-                                        self.set_final_result( Err( xml_error ) )
+                                        self.set_final_result(Err(xml_error))
                                     },
                             }
                     },
-                Err( lexer_error ) =>
-                    return self.set_final_result( Err( lexer_error ) ),
+                Err(lexer_error) =>
+                    return self.set_final_result(Err(lexer_error)),
             }
         }
 
@@ -299,7 +299,7 @@ impl PullParser {
         } else {
             self_error!(self; "Unexpected end of stream: still inside the root element")
         };
-        self.set_final_result( ev )
+        self.set_final_result(ev)
     }
 
     // This function is to be called when a terminal event is reached.


### PR DESCRIPTION
Issue #106: This time it should be okay.

The tests are passed.
The error is popped up to the very `EventReader::next` call.
The EventReader's source is accessible via `er.source()` and `er.source_mut()`.

I'm still not sure whether it is convenient to dive into the cases of `reader::Error` though...