### PR TITLE
Add into_inner() method for EventWriter so that we can get the underlying writer back after we're finished

### DIFF
--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -71,4 +71,9 @@ impl<W: Write> EventWriter<W> {
                 self.emitter.emit_characters(&mut self.sink, content)
         }
     }
+
+    /// Unwraps this `EventWriter`, returning the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.sink
+    }
 }


### PR DESCRIPTION
This is useful, for example, if you want to incorporate an `EventWriter<Vec<u8>>` into a structure, and then get the vector when you're done consuming input.