### PR TITLE
Implement From<std::io::Error> for xml::reader::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml-rs"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT"
 description = "An XML library in pure Rust"

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -86,6 +86,15 @@ impl From<util::CharReadError> for Error {
     }
 }
 
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error {
+            pos: TextPosition::new(),
+            kind: ErrorKind::Io(e),
+        }
+    }
+}
+
 impl Clone for ErrorKind {
     fn clone(&self) -> Self {
         use self::ErrorKind::*;

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -73,14 +73,8 @@ impl From<util::CharReadError> for Error {
             pos: TextPosition::new(),
             kind: match e {
                 UnexpectedEof => ErrorKind::UnexpectedEof,
-                Utf8(ref reason) => ErrorKind::Utf8(reason.clone()),
-                Io(ref io_error) =>
-                    ErrorKind::Io(
-                        io::Error::new(
-                            io_error.kind(),
-                            error_description(io_error)
-                        )
-                    ),
+                Utf8(reason) => ErrorKind::Utf8(reason),
+                Io(io_error) => ErrorKind::Io(io_error),
             }
         }
     }

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -2,12 +2,28 @@ extern crate xml;
 
 use std::env;
 use std::fmt;
+use std::fs::File;
 use std::io::{BufRead, BufReader, Write, stderr};
+use std::path::Path;
 use std::sync::{Once, ONCE_INIT};
 
 use xml::name::OwnedName;
 use xml::common::Position;
-use xml::reader::{Result, XmlEvent, ParserConfig};
+use xml::reader::{Result, XmlEvent, ParserConfig, EventReader};
+
+/// Dummy function that opens a file, parses it, and returns a `Result`.
+/// There can be IO errors (from `File::open`) and XML errors (from the parser).
+/// Having `impl From<std::io::Error> for xml::reader::Error` allows the user to
+/// do this without defining their own error type.
+#[allow(dead_code)]
+fn count_event_in_file(name: &Path) -> Result<usize> {
+    let mut event_count = 0;
+    for event in EventReader::new(BufReader::new(try!(File::open(name)))) {
+        try!(event);
+        event_count += 1;
+    }
+    Ok(event_count)
+}
 
 #[test]
 fn sample_1_short() {


### PR DESCRIPTION
This allows users to use `try!(File::open(…))` or other IO-related things in a function that also does XML parsing and returns `xml::reader::Result`.

See the added function in `tests/event_reader.rs` for an example.