### PR TITLE
Allow bitflags 0.5 and 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml-rs"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT"
 description = "An XML library in pure Rust"
@@ -18,4 +18,4 @@ name = "xml-analyze"
 path = "src/analyze.rs"
 
 [dependencies]
-bitflags = "0.7"
+bitflags = ">=0.5, <0.8"


### PR DESCRIPTION
0.5 was the last version that allows Rust <1.8.