### PR TITLE
Add missing Debug impl for XmlVersion

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -87,6 +87,11 @@ impl fmt::Display for XmlVersion {
     }
 }
 
+impl fmt::Debug for XmlVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
 
 /// Checks whether the given character is a white space character (`S`)
 /// as is defined by XML 1.1 specification, [section 2.3][1].


### PR DESCRIPTION
xml::common::XmlVersion is public, but it does not have the Debug trait, making it difficult to use in external structures which do implement Debug.

This change fixes it.