### PR TITLE
Adding extra entities configuration in ParserConfig

### DIFF
--- a/src/reader/parser/inside_reference.rs
+++ b/src/reader/parser/inside_reference.rs
@@ -48,7 +48,13 @@ impl PullParser {
                             }
                         }
                     },
-                    _ => Err(self_error!(self; "Unexpected entity: {}", name))
+                    _ => {
+                        if let Some(v) = self.config.extra_entities.get(&name) {
+                            Ok(v.clone())
+                        } else {
+                            Err(self_error!(self; "Unexpected entity: {}", name))
+                        }
+                    }
                 };
                 match c {
                     Ok(c) => {

--- a/tests/documents/sample_5.xml
+++ b/tests/documents/sample_5.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE data SYSTEM "abcd.dtd">
+<p>
+    <a>test&nbsp;&copy;</a>
+</p>
+
+

--- a/tests/documents/sample_5_short.txt
+++ b/tests/documents/sample_5_short.txt
@@ -1,0 +1,7 @@
+StartDocument(1.0, utf-8)
+StartElement(p)
+StartElement(a)
+Characters("test ©")
+EndElement(a)
+EndElement(p)
+EndDocument

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -147,6 +147,23 @@ fn sample_4_full() {
 }
 
 #[test]
+fn sample_5_short() {
+    test(
+        include_bytes!("documents/sample_5.xml"),
+        include_bytes!("documents/sample_5_short.txt"),
+        ParserConfig::new()
+            .ignore_comments(true)
+            .whitespace_to_characters(true)
+            .cdata_to_characters(true)
+            .trim_whitespace(true)
+            .coalesce_characters(true)
+            .add_entity("nbsp", ' ')
+            .add_entity("copy", '©'),
+        false
+    );
+}
+
+#[test]
 fn eof_1() {
     test(
         br#"<?xml"#,


### PR DESCRIPTION
This is useful to parse xhtml files that contains custom html entities like &amp;nbsp; or &amp;copy;

I'm writting an [epub reader lib][1] and I'm having problems parsing xhtml files that contains &amp;nbsp; so I need a way to deal with this.

[Currently I've done a workaround][2], removing the unexpected entities from the source xhtml before parse it, but it could be great to be able to configure this in the ParserConfig.

At first I thought about a simple boolean configuration to "ignore_unexpected_entities", but then I thought that it could be better to be able to add custom entities to the parser so that is what I've done in this pull request.

[1]: https://github.com/danigm/epub-rs
[2]: https://github.com/danigm/epub-rs/commit/cdb9bbc82e5c510ae1e5301f6f3ae9f80444efbf