### PR TITLE
Add Debug to writer::XmlEvent

### DIFF
--- a/src/writer/events.rs
+++ b/src/writer/events.rs
@@ -11,6 +11,7 @@ use namespace::{Namespace, NS_NO_PREFIX};
 ///
 /// Objects of this enum are consumed by `EventWriter`. They correspond to different parts of
 /// an XML document.
+#[derive(Debug)]
 pub enum XmlEvent<'a> {
     /// Corresponds to XML document declaration.
     ///


### PR DESCRIPTION
The writer::XmlEvent structure had no Debug impl despite being public.