### PR TITLE
Proposal: Stream support reopen parser

### DIFF
--- a/src/reader/config.rs
+++ b/src/reader/config.rs
@@ -62,7 +62,19 @@ pub struct ParserConfig {
     /// however, it is convenient to make the parser recognize additional entities which
     /// are also not available through the DTD definitions (especially given that at the moment
     /// DTD parsing is not supported).
-    pub extra_entities: HashMap<String, char>
+    pub extra_entities: HashMap<String, char>,
+
+    /// Whether or not the parser should ignore the end of stream. Default is false.
+    ///
+    /// By default the parser will either error out when it encounters a premature end of
+    /// stream or complete normally if the end of stream was expected. If you want to continue
+    /// reading from a stream whose input is supplied progressively, you can set this option to true.
+    /// In this case the parser will allow you to invoke the next() method even if a supposed end
+    /// of stream has happened.
+    ///
+    /// Note that support for this functionality is incomplete; for example, the parser will fail if
+    /// the premature end of stream happens inside PCDATA. Therefore, use this option at your own risk.
+    pub ignore_end_of_stream: bool
 }
 
 impl ParserConfig {
@@ -85,7 +97,8 @@ impl ParserConfig {
             cdata_to_characters: false,
             ignore_comments: true,
             coalesce_characters: true,
-            extra_entities: HashMap::new()
+            extra_entities: HashMap::new(),
+            ignore_end_of_stream: false
         }
     }
 
@@ -146,5 +159,6 @@ gen_setters! { ParserConfig,
     whitespace_to_characters: val bool,
     cdata_to_characters: val bool,
     ignore_comments: val bool,
-    coalesce_characters: val bool
+    coalesce_characters: val bool,
+    ignore_end_of_stream: val bool
 }

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -264,6 +264,10 @@ impl Lexer {
     #[inline]
     pub fn outside_comment(&mut self) { self.inside_comment = false; }
 
+    /// Reset the eof handled flag of the lexer.
+    #[inline]
+    pub fn reset_eof_handled(&mut self) { self.eof_handled = false; }
+
     /// Tries to read the next token from the buffer.
     ///
     /// It is possible to pass different instaces of `BufReader` each time

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -97,6 +97,10 @@ impl<R: Read> Events<R> {
     pub fn into_inner(self) -> EventReader<R> {
         self.reader
     }
+
+    pub fn source(&self) -> &R { &self.reader.source }
+    pub fn source_mut(&mut self) -> &mut R { &mut self.reader.source }
+
 }
 
 impl<R: Read> Iterator for Events<R> {
@@ -104,7 +108,7 @@ impl<R: Read> Iterator for Events<R> {
 
     #[inline]
     fn next(&mut self) -> Option<Result<XmlEvent>> {
-        if self.finished { None }
+        if self.finished && !self.reader.parser.is_ignoring_end_of_stream() { None }
         else {
             let ev = self.reader.next();
             match ev {

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -120,6 +120,9 @@ impl PullParser {
             pop_namespace: false
         }
     }
+
+    /// Checks if this parser ignores the end of stream errors.
+    pub fn is_ignoring_end_of_stream(&self) -> bool { self.config.ignore_end_of_stream }
 }
 
 impl Position for PullParser {
@@ -297,7 +300,13 @@ impl PullParser {
                 self_error!(self; "Unexpected end of stream")  // TODO: add expected hint?
             }
         } else {
-            self_error!(self; "Unexpected end of stream: still inside the root element")
+            if self.config.ignore_end_of_stream {
+                self.final_result = None;
+                self.lexer.reset_eof_handled();
+                return self_error!(self; "Unexpected end of stream: still inside the root element");
+            } else {
+                self_error!(self; "Unexpected end of stream: still inside the root element")
+            }
         };
         self.set_final_result(ev)
     }

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -1,0 +1,101 @@
+extern crate xml;
+
+use std::io::{Cursor, Write};
+
+use xml::EventReader;
+use xml::reader::ParserConfig;
+use xml::reader::XmlEvent;
+
+macro_rules! assert_match {
+    ($actual:expr, $expected:pat) => {
+        match $actual {
+            $expected => {},
+            _ => panic!("assertion failed: `(left matches right)` \
+                        (left: `{:?}`, right: `{}`", $actual, stringify!($expected))
+        }
+    };
+    ($actual:expr, $expected:pat if $guard:expr) => {
+        match $actual {
+            $expected if $guard => {},
+            _ => panic!("assertion failed: `(left matches right)` \
+                        (left: `{:?}`, right: `{} if {}`",
+                        $actual, stringify!($expected), stringify!($guard))
+        }
+    }
+}
+
+fn write_and_reset_position<W>(c: &mut Cursor<W>, data: &[u8]) where Cursor<W>: Write {
+    let p = c.position();
+    c.write_all(data).unwrap();
+    c.set_position(p);
+}
+
+#[test]
+fn reading_streamed_content() {
+    let buf = Cursor::new(b"<root>".to_vec());
+    let reader = EventReader::new(buf);
+
+    let mut it = reader.into_iter();
+
+    assert_match!(it.next(), Some(Ok(XmlEvent::StartDocument { .. })));
+    assert_match!(it.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "root");
+
+    write_and_reset_position(it.source_mut(), b"<child-1>content</child-1>");
+    assert_match!(it.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-1");
+    assert_match!(it.next(), Some(Ok(XmlEvent::Characters(ref c))) if c == "content");
+    assert_match!(it.next(), Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "child-1");
+
+    write_and_reset_position(it.source_mut(), b"<child-2/>");
+    assert_match!(it.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-2");
+    assert_match!(it.next(), Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "child-2");
+
+    write_and_reset_position(it.source_mut(), b"<child-3/>");
+    assert_match!(it.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-3");
+    assert_match!(it.next(), Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "child-3");
+    // doesn't seem to work because of how tags parsing is done
+//    write_and_reset_position(it.source_mut(), b"some text");
+   // assert_match!(it.next(), Some(Ok(XmlEvent::Characters(ref c))) if c == "some text");
+
+    write_and_reset_position(it.source_mut(), b"</root>");
+    assert_match!(it.next(), Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "root");
+    assert_match!(it.next(), Some(Ok(XmlEvent::EndDocument)));
+    assert_match!(it.next(), None);
+}
+
+#[test]
+fn reading_streamed_content2() {
+    let buf = Cursor::new(b"<root>".to_vec());
+    let mut config = ParserConfig::new();
+    config.ignore_end_of_stream = true;
+    let readerb = EventReader::new_with_config(buf, config);
+
+    let mut reader = readerb.into_iter();
+
+    assert_match!(reader.next(), Some(Ok(XmlEvent::StartDocument { .. })));
+    assert_match!(reader.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "root");
+
+    write_and_reset_position(reader.source_mut(), b"<child-1>content</child-1>");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-1");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::Characters(ref c))) if c == "content");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "child-1");
+
+    write_and_reset_position(reader.source_mut(), b"<child-2>content</child-2>");
+
+    assert_match!(reader.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-2");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::Characters(ref c))) if c == "content");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "child-2");
+    assert_match!(reader.next(), Some(Err(_)));
+    write_and_reset_position(reader.source_mut(), b"<child-3></child-3>");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-3");
+    write_and_reset_position(reader.source_mut(), b"<child-4 type='get'");
+    match reader.next() {
+       None |
+       Some(Ok(_)) => {
+          panic!("At this point, parser must not detect something.");
+       },
+       Some(Err(_)) => {}
+    };
+    write_and_reset_position(reader.source_mut(), b" />");
+    assert_match!(reader.next(), Some(Ok(XmlEvent::StartElement { ref name, .. })) if name.local_name == "child-4");
+}
+


### PR DESCRIPTION
Hello,

I'm working on an xmpp library and I need to be able to reopen the parser to consume new bytes.

It's a first step to be able to reset some condition, I use it like that:

```rust
loop {
    // My parser is an instance of EventReader<Buffer>,
    // Buffer is a custom struct that hold my buffer and expose some useful methods.
    // It implement Read 
    if self.parser.source().available_data() > 0 {
        self.parser.reopen_parser();
    }
    match self.parser.next() { ... }
}
```

What do you think?

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>