### PR TITLE
Using string instead of char to convert XML entities

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -104,6 +104,10 @@ pub fn is_whitespace_char(c: char) -> bool {
     }
 }
 
+pub fn is_whitespace_str(s: &str) -> bool {
+    s.chars().fold(true, |acc, c| acc && is_whitespace_char(c))
+}
+
 /// Checks whether the given character is a name start character (`NameStartChar`)
 /// as is defined by XML 1.1 specification, [section 2.3][1].
 ///

--- a/src/common.rs
+++ b/src/common.rs
@@ -104,8 +104,11 @@ pub fn is_whitespace_char(c: char) -> bool {
     }
 }
 
+/// Checks whether the given string is compound only by white space
+/// characters (`S`) using the previous is_whitespace_char to check
+/// all characters of this string
 pub fn is_whitespace_str(s: &str) -> bool {
-    s.chars().fold(true, |acc, c| acc && is_whitespace_char(c))
+    s.chars().all(is_whitespace_char)
 }
 
 /// Checks whether the given character is a name start character (`NameStartChar`)

--- a/src/reader/config.rs
+++ b/src/reader/config.rs
@@ -62,7 +62,7 @@ pub struct ParserConfig {
     /// however, it is convenient to make the parser recognize additional entities which
     /// are also not available through the DTD definitions (especially given that at the moment
     /// DTD parsing is not supported).
-    pub extra_entities: HashMap<String, char>,
+    pub extra_entities: HashMap<String, String>,
 
     /// Whether or not the parser should ignore the end of stream. Default is false.
     ///
@@ -136,13 +136,13 @@ impl ParserConfig {
     /// let mut source: &[u8] = b"...";
     ///
     /// let reader = ParserConfig::new()
-    ///     .add_entity("nbsp", ' ')
-    ///     .add_entity("copy", '©')
-    ///     .add_entity("reg", '®')
+    ///     .add_entity("nbsp", " ")
+    ///     .add_entity("copy", "©")
+    ///     .add_entity("reg", "®")
     ///     .create_reader(&mut source);
     /// ```
-    pub fn add_entity<S: Into<String>>(mut self, entity: S, value: char) -> ParserConfig {
-        self.extra_entities.insert(entity.into(), value);
+    pub fn add_entity<S: Into<String>>(mut self, entity: S, value: &str) -> ParserConfig {
+        self.extra_entities.insert(entity.into(), value.into());
         self
     }
 }

--- a/src/reader/config.rs
+++ b/src/reader/config.rs
@@ -141,7 +141,7 @@ impl ParserConfig {
     ///     .add_entity("reg", "®")
     ///     .create_reader(&mut source);
     /// ```
-    pub fn add_entity<S: Into<String>>(mut self, entity: S, value: &str) -> ParserConfig {
+    pub fn add_entity<S: Into<String>, T: Into<String>>(mut self, entity: S, value: T) -> ParserConfig {
         self.extra_entities.insert(entity.into(), value.into());
         self
     }

--- a/src/reader/parser/inside_reference.rs
+++ b/src/reader/parser/inside_reference.rs
@@ -1,6 +1,6 @@
 use std::char;
 
-use common::{is_name_start_char, is_name_char, is_whitespace_char};
+use common::{is_name_start_char, is_name_char, is_whitespace_str};
 
 use reader::lexer::Token;
 
@@ -20,11 +20,11 @@ impl PullParser {
                 let name = self.data.take_ref_data();
                 let name_len = name.len();  // compute once
                 let c = match &name[..] {
-                    "lt"   => Ok('<'),
-                    "gt"   => Ok('>'),
-                    "amp"  => Ok('&'),
-                    "apos" => Ok('\''),
-                    "quot" => Ok('"'),
+                    "lt"   => Ok('<'.to_string()),
+                    "gt"   => Ok('>'.to_string()),
+                    "amp"  => Ok('&'.to_string()),
+                    "apos" => Ok('\''.to_string()),
+                    "quot" => Ok('"'.to_string()),
                     ""     => Err(self_error!(self; "Encountered empty entity")),
                     _ if name_len > 2 && name.starts_with("#x") => {
                         let num_str = &name[2..name_len];
@@ -32,7 +32,7 @@ impl PullParser {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
                             match u32::from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
-                                Some(c) => Ok(c),
+                                Some(c) => Ok(c.to_string()),
                                 None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
                             }
                         }
@@ -43,7 +43,7 @@ impl PullParser {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
                             match u32::from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
-                                Some(c) => Ok(c),
+                                Some(c) => Ok(c.to_string()),
                                 None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
                             }
                         }
@@ -58,8 +58,8 @@ impl PullParser {
                 };
                 match c {
                     Ok(c) => {
-                        self.buf.push(c);
-                        if prev_st == State::OutsideTag && !is_whitespace_char(c) {
+                        self.buf.push_str(&c);
+                        if prev_st == State::OutsideTag && !is_whitespace_str(&c) {
                             self.inside_whitespace = false;
                         }
                         self.into_state_continue(prev_st)

--- a/tests/documents/sample_5.xml
+++ b/tests/documents/sample_5.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE data SYSTEM "abcd.dtd">
 <p>
-    <a>test&nbsp;&copy;</a>
+    <a>test&nbsp;&copy;&NotEqualTilde;</a>
 </p>
 
 

--- a/tests/documents/sample_5_short.txt
+++ b/tests/documents/sample_5_short.txt
@@ -1,7 +1,7 @@
 StartDocument(1.0, utf-8)
 StartElement(p)
 StartElement(a)
-Characters("test ©")
+Characters("test ©≂̸")
 EndElement(a)
 EndElement(p)
 EndDocument

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -157,8 +157,9 @@ fn sample_5_short() {
             .cdata_to_characters(true)
             .trim_whitespace(true)
             .coalesce_characters(true)
-            .add_entity("nbsp", ' ')
-            .add_entity("copy", '©'),
+            .add_entity("nbsp", " ")
+            .add_entity("copy", "©")
+            .add_entity("NotEqualTilde", "≂̸"),
         false
     );
 }


### PR DESCRIPTION
Some entities doesn't have one char, like &NotEqualTilde; so we need to
enable the use of String instead of char for parse entities.

This change fixes the bug report: https://github.com/netvl/xml-rs/issues/149