### PR TITLE
XML Files with a Byte Order Mark should work

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Unit tests expect these files to have unix line endings, even on windows
+tests/documents/* text eol=lf

--- a/tests/documents/sample_4.xml
+++ b/tests/documents/sample_4.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE data SYSTEM "abcd.dtd">
 <p:data xmlns:p="urn:x" z=">">
     <!-- abcd &lt; &gt; &amp; -->


### PR DESCRIPTION
Hello,

I too was affected by bug #155 - this bug means that when xml-rs attempts to parse any XML with a Byte Order Mark at the start, it fails and errors out, even though this is valid UTF-8 XML.

This PR is my attempt to fix the issue. If it is not any good, let me know how to improve the implementation.

I fixed it by simply having it check for the BOM bytes in the edge case where it finds non-whitespace characters before the root tag, in outside_tag.rs. 

I have also added a .gitattributes file because I found tests fail on windows machines, as they expect unix line endings.

Finally I changed the fourth sample XML so that it has a UTF-8 bom mark at start, this constitutes the test.

I did not consider any other BOM marks (eg UTF-16 ones etc) because xml-rs only cares about utf-8.

Thank you!


