### PR TITLE
Remove use of unsafe in favor of lazy_static!.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/lib.rs"
 [[bin]]
 name = "xml-analyze"
 path = "src/analyze.rs"
+
+[dependencies]
+lazy_static = "1.2.0"


### PR DESCRIPTION
There seems to be no reason to have any unsafe code in the tests. Especially if the crate is advertised as "pure Rust".

This patch removes the unsafe code at the cost of the popular `lazy_static!` macro.