### PR TITLE
Refactored error handling to strong typing

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -69,7 +69,7 @@ impl Position for TextPosition {
 }
 
 /// XML version enumeration.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum XmlVersion {
     /// XML version 1.0.
     Version10,

--- a/src/name.rs
+++ b/src/name.rs
@@ -169,7 +169,7 @@ impl<'a, 'b:'a> fmt::Display for ReprDisplay<'a, 'b> {
 /// An owned variant of `Name`.
 ///
 /// Everything about `Name` applies to this structure as well.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct OwnedName {
     /// A local name, e.g. `string` in `xsi:string`.
     pub local_name: String,

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -1,19 +1,124 @@
 
 use std::io;
-use std::borrow::Cow;
 use std::fmt;
-use std::error;
 use std::str;
 
 use util;
-use common::{Position, TextPosition};
+use common::{Position, TextPosition, XmlVersion};
+use reader::lexer::Token;
+use name::OwnedName;
+use namespace::{NS_XMLNS_PREFIX, NS_XML_PREFIX};
 
 #[derive(Debug)]
 pub enum ErrorKind {
-    Syntax(Cow<'static, str>),
+    Syntax(SyntaxError),
     Io(io::Error),
     Utf8(str::Utf8Error),
     UnexpectedEof,
+}
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::ErrorKind::*;
+        match self {
+            Syntax(err) => write!(f, "Syntax error: {}", err),
+            Io(err) => write!(f, "IO error: {}", err),
+            Utf8(err) => write!(f, "Utf8 encoding error: {}", err),
+            UnexpectedEof => write!(f, "Unexpected EOF"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SyntaxError {
+    UnexpectedEof,
+    NoRootElement,
+    UnbalancedRootElement,
+    InvalidQualifiedName(String),
+    UnexpectedQualifiedName(Token),
+    UnexpectedOpeningTag,
+    MissingNamespace(OwnedName),
+    UnboundAttribute(OwnedName),
+    UnboundPrefix(OwnedName),
+    UnexpectedClosingTag(OwnedName, OwnedName),
+    UnexpectedTokenBefore(&'static str, char),
+    UnexpectedTokenOutsideRoot(Token),
+    UnexpectedToken(Token),
+    UnexpectedTokenInEntity(Token),
+    UnexpectedTokenInClosingTag(Token),
+    UnexpectedTokenInOpeningTag(Token),
+    UnexpectedName(OwnedName),
+    ProcessingInstructionWithoutName,
+    /// Found <?xml-like PI not at the beginning of a document,
+    /// which is an error, see section 2.6 of XML 1.1 spec
+    InvalidXmlProcessingInstruction(String),
+    InvalidProcessingInstruction(String),
+    UnexpectedProcessingInstruction(Token),
+    InvalidNamePrefix(Option<String>),
+    RedefinedAttribute(OwnedName),
+    CannotUndefinePrefix(String),
+    CannotRedefineXmlnsPrefix,
+    CannotRedefineXmlPrefix,
+    UnexpectedTokenInsideXml(Token),
+    UnexpectedNameInsideXml(OwnedName),
+    UnexpectedXmlVersion(Option<XmlVersion>),
+    InvalidStandaloneDeclaration(String),
+    EmptyEntity,
+    NullCharacterEntity,
+    InvalidHexCharacterEntity(String),
+    InvalidDecCharacterEntity(String),
+    UnexpectedEntity(String),
+    InvalidDefaultNamespace(String),
+    /// Double dash ("--") is illegal inside a comment
+    DoubleDashInComment,
+}
+
+impl fmt::Display for SyntaxError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::SyntaxError::*;
+        match self {
+            UnexpectedEof => write!(f, "Unexpected end of stream"),
+            NoRootElement => write!(f, "Unexpected end of stream: no root element found"),
+            UnbalancedRootElement => write!(f, "Unexpected end of stream: still inside the root element"),
+            InvalidQualifiedName(e) => write!(f, "Qualified name is invalid: {}", e),
+            UnexpectedQualifiedName(e) => write!(f, "Unexpected token inside qualified name: {}", e),
+            UnexpectedOpeningTag => write!(f, "Unexpected token inside attribute value: <"),
+            MissingNamespace(name) => write!(f, "Element {} prefix is unbound", name),
+            UnboundAttribute(name) => write!(f, "Attribute {} prefix is unbound", name),
+            UnboundPrefix(name) => write!(f, "Element {} prefix is unbound", name),
+            UnexpectedClosingTag(expected_name, got_name) => write!(f, "Unexpected closing tag: {}, expected {}", expected_name, got_name),
+            UnexpectedToken(token) => write!(f, "Unexpected token: {}", token),
+            UnexpectedTokenBefore(before, c) => write!(f, "Unexpected token '{}' before '{}'", before, c),
+            UnexpectedTokenOutsideRoot(token) => write!(f, "Unexpected characters outside the root element: {}", token),
+            UnexpectedTokenInOpeningTag(token) => write!(f, "Unexpected token inside opening tag: {}", token),
+            UnexpectedTokenInClosingTag(token) => write!(f, "Unexpected token inside closing tag: {}", token),
+            UnexpectedTokenInEntity(token) => write!(f, "Unexpected token inside entity: {}", token),
+            UnexpectedName(name) => write!(f, "Unexpected name: {}", name),
+            ProcessingInstructionWithoutName => write!(f, "Encountered processing instruction without name"),
+            InvalidXmlProcessingInstruction(name) => write!(f,
+                "Invalid processing instruction: <?{} - \"<?xml\"-like PI is \
+                 only valid at the beginning of the document", name),
+            InvalidProcessingInstruction(name) => write!(f, "Invalid processing instruction: <?{}", name),
+            UnexpectedProcessingInstruction(token) => write!(f, "Unexpected token inside processing instruction: <?{}", token),
+            InvalidNamePrefix(Some(prefix)) => write!(f, "'{}' cannot be an element name prefix", prefix),
+            InvalidNamePrefix(None) => write!(f, "Empty element name prefix"),
+            RedefinedAttribute(name) => write!(f, "Attribute '{}' is redefined", name),
+            CannotUndefinePrefix(ln) => write!(f, "Cannot undefine prefix '{}'", ln),
+            CannotRedefineXmlnsPrefix => write!(f, "Cannot redefine XMLNS prefix '{}'", NS_XMLNS_PREFIX),
+            CannotRedefineXmlPrefix => write!(f, "Prefix '{}' cannot be rebound to another value", NS_XML_PREFIX),
+            UnexpectedTokenInsideXml(token) => write!(f, "Unexpected token inside XML declaration: {}", token),
+            UnexpectedNameInsideXml(name) => write!(f, "Unexpected name inside XML declaration: {}", name),
+            UnexpectedXmlVersion(Some(version)) => write!(f, "Invalid XML version: {}", version),
+            UnexpectedXmlVersion(None) => write!(f, "No XML version specified"),
+            InvalidStandaloneDeclaration(value) => write!(f, "Invalid standalone declaration value: {}", value),
+            EmptyEntity => write!(f, "Encountered empty entity"),
+            NullCharacterEntity => write!(f, "Null character entity is not allowed"),
+            InvalidHexCharacterEntity(name) => write!(f, "Invalid hexadecimal character number in an entity: {}", name),
+            InvalidDecCharacterEntity(name) => write!(f, "Invalid decimal character number in an entity: {}", name),
+            UnexpectedEntity(name) => write!(f, "Unexpected entity: {}", name),
+            InvalidDefaultNamespace(name) => write!(f,  "Namespace '{}' cannot be default", name),
+            DoubleDashInComment => write!(f, "Unexpected double dash inside a comment: \"--\""),
+        }
+    }
 }
 
 /// An XML parsing error.
@@ -21,13 +126,13 @@ pub enum ErrorKind {
 /// Consists of a 2D position in a document and a textual message describing the error.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Error {
-    pos: TextPosition,
-    kind: ErrorKind,
+    pub pos: TextPosition,
+    pub kind: ErrorKind,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}", self.pos, self.msg())
+        write!(f, "{} {}", self.pos, self.kind)
     }
 }
 
@@ -36,28 +141,7 @@ impl Position for Error {
     fn position(&self) -> TextPosition { self.pos }
 }
 
-impl Error {
-    /// Returns a reference to a message which is contained inside this error.
-    #[inline]
-    pub fn msg(&self) -> &str {
-        use self::ErrorKind::*;
-        match self.kind {
-            UnexpectedEof => &"Unexpected EOF",
-            Utf8(ref reason) => error_description(reason),
-            Io(ref io_error) => error_description(io_error),
-            Syntax(ref msg) => msg.as_ref(),
-        }
-    }
-
-    pub fn kind(&self) -> &ErrorKind { &self.kind }
-}
-
-impl error::Error for Error {
-    #[inline]
-    fn description(&self) -> &str { self.msg() }
-}
-
-impl<'a, P, M> From<(&'a P, M)> for Error where P: Position, M: Into<Cow<'static, str>> {
+impl<'a, P, M> From<(&'a P, M)> for Error where P: Position, M: Into<SyntaxError> {
     fn from(orig: (&'a P, M)) -> Self {
         Error{
             pos: orig.0.position(),
@@ -80,6 +164,7 @@ impl From<util::CharReadError> for Error {
     }
 }
 
+/*
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error {
@@ -88,34 +173,33 @@ impl From<io::Error> for Error {
         }
     }
 }
+*/
 
 impl Clone for ErrorKind {
     fn clone(&self) -> Self {
         use self::ErrorKind::*;
+        use std::error::Error;
         match *self {
             UnexpectedEof => UnexpectedEof,
             Utf8(ref reason) => Utf8(reason.clone()),
-            Io(ref io_error) => Io(io::Error::new(io_error.kind(), error_description(io_error))),
+            Io(ref io_error) => Io(io::Error::new(io_error.kind(), io_error.description())),
             Syntax(ref msg) => Syntax(msg.clone()),
         }
     }
 }
+
 impl PartialEq for ErrorKind {
     fn eq(&self, other: &ErrorKind) -> bool {
         use self::ErrorKind::*;
         match (self, other) {
             (&UnexpectedEof, &UnexpectedEof) => true,
             (&Utf8(ref left), &Utf8(ref right)) => left == right,
-            (&Io(ref left), &Io(ref right)) =>
-                left.kind() == right.kind() &&
-                error_description(left) == error_description(right),
-            (&Syntax(ref left), &Syntax(ref right)) =>
-                left == right,
+            (&Io(ref left), &Io(ref right)) => left.kind() == right.kind(),
+            (&Syntax(ref left), &Syntax(ref right)) => left == right,
 
             (_, _) => false,
         }
     }
 }
-impl Eq for ErrorKind {}
 
-fn error_description(e: &error::Error) -> &str { e.description() }
+impl Eq for ErrorKind {}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -19,7 +19,7 @@ mod config;
 mod events;
 
 mod error;
-pub use self::error::{Error, ErrorKind};
+pub use self::error::{Error, SyntaxError, ErrorKind};
 
 /// A result type yielded by `XmlReader`.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/reader/parser/inside_comment.rs
+++ b/src/reader/parser/inside_comment.rs
@@ -1,5 +1,6 @@
 use reader::events::XmlEvent;
 use reader::lexer::Token;
+use reader::error::SyntaxError;
 
 use super::{Result, PullParser, State};
 
@@ -7,7 +8,7 @@ impl PullParser {
     pub fn inside_comment(&mut self, t: Token) -> Option<Result> {
         match t {
             // Double dash is illegal inside a comment
-            Token::Chunk(ref s) if &s[..] == "--" => Some(self_error!(self; "Unexpected token inside a comment: --")),
+            Token::Chunk(ref s) if &s[..] == "--" => Some(self_error!(self; SyntaxError::DoubleDashInComment)),
 
             Token::CommentEnd if self.config.ignore_comments => {
                 self.lexer.outside_comment();

--- a/src/reader/parser/inside_processing_instruction.rs
+++ b/src/reader/parser/inside_processing_instruction.rs
@@ -68,7 +68,7 @@ impl PullParser {
                     }
                 }
 
-                _ => Some(self_error!(self; SyntaxError::UnexpectedProcessingInstruction(t)))
+                _ => Some(self_error!(self; SyntaxError::UnexpectedProcessingInstruction(self.buf.clone(), t)))
             },
 
             ProcessingInstructionSubstate::PIInsideData => match t {

--- a/src/reader/parser/inside_reference.rs
+++ b/src/reader/parser/inside_reference.rs
@@ -3,6 +3,7 @@ use std::char;
 use common::{is_name_start_char, is_name_char, is_whitespace_str};
 
 use reader::lexer::Token;
+use reader::error::SyntaxError;
 
 use super::{Result, PullParser, State};
 
@@ -25,26 +26,26 @@ impl PullParser {
                     "amp"  => Ok('&'.to_string()),
                     "apos" => Ok('\''.to_string()),
                     "quot" => Ok('"'.to_string()),
-                    ""     => Err(self_error!(self; "Encountered empty entity")),
+                    ""     => Err(self_error!(self; SyntaxError::EmptyEntity)),
                     _ if name_len > 2 && name.starts_with("#x") => {
                         let num_str = &name[2..name_len];
                         if num_str == "0" {
-                            Err(self_error!(self; "Null character entity is not allowed"))
+                            Err(self_error!(self; SyntaxError::NullCharacterEntity))
                         } else {
                             match u32::from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
                                 Some(c) => Ok(c.to_string()),
-                                None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
+                                None    => Err(self_error!(self; SyntaxError::InvalidHexCharacterEntity(name.clone())))
                             }
                         }
                     }
                     _ if name_len > 1 && name.starts_with('#') => {
                         let num_str = &name[1..name_len];
                         if num_str == "0" {
-                            Err(self_error!(self; "Null character entity is not allowed"))
+                            Err(self_error!(self; SyntaxError::NullCharacterEntity))
                         } else {
                             match u32::from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
                                 Some(c) => Ok(c.to_string()),
-                                None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
+                                None    => Err(self_error!(self; SyntaxError::InvalidDecCharacterEntity(name.clone())))
                             }
                         }
                     },
@@ -52,7 +53,7 @@ impl PullParser {
                         if let Some(v) = self.config.extra_entities.get(&name) {
                             Ok(v.clone())
                         } else {
-                            Err(self_error!(self; "Unexpected entity: {}", name))
+                            Err(self_error!(self; SyntaxError::UnexpectedEntity(name)))
                         }
                     }
                 };
@@ -68,7 +69,7 @@ impl PullParser {
                 }
             }
 
-            _ => Some(self_error!(self; "Unexpected token inside an entity: {}", t))
+            _ => Some(self_error!(self; SyntaxError::UnexpectedTokenInEntity(t)))
         }
     }
 }

--- a/src/reader/parser/outside_tag.rs
+++ b/src/reader/parser/outside_tag.rs
@@ -2,6 +2,7 @@ use common::is_whitespace_char;
 
 use reader::events::XmlEvent;
 use reader::lexer::Token;
+use reader::error::SyntaxError;
 
 use super::{
     Result, PullParser, State, ClosingTagSubstate, OpeningTagSubstate,
@@ -17,7 +18,7 @@ impl PullParser {
             Token::Whitespace(_) if self.depth() == 0 => None,  // skip whitespace outside of the root element
 
             _ if t.contains_char_data() && self.depth() == 0 =>
-                Some(self_error!(self; "Unexpected characters outside the root element: {}", t)),
+                Some(self_error!(self; SyntaxError::UnexpectedTokenOutsideRoot(t))),
 
             Token::Whitespace(_) if self.config.trim_whitespace && !self.buf_has_data() => None,
 
@@ -122,7 +123,7 @@ impl PullParser {
                         self.into_state(State::InsideCData, next_event)
                     }
 
-                    _ => Some(self_error!(self; "Unexpected token: {}", t))
+                    _ => Some(self_error!(self; SyntaxError::UnexpectedToken(t)))
                 }
             }
         }


### PR DESCRIPTION
I've noticed that the error handling in this crate is highly relying on Strings (or `Cow<'static, str>`, which isn't much better). This is a problem mainly for tests, performance and reliability - error cases allocate unnecessarily, tests can only compare via the `.description()` message (which is unreliable, you should never cast something to a String to compare the String, if it is possible to just compare the enum directly). Meaning, you can't change the error message, without everything failing - everything is stringly typed. And lastly, there is no overview over what errors can actually occur (because a String could be anything, doesn't say anything about what type of error can occur).

During making this change I needed to remove the `msg()` function of the `Error`. `std::error::Error` - the reason for that is that the `error.description()` returns a `&str`, which means that I can't dynamically format messages (like I can with `Display`). Further, the `description()` method is half-depreceated (and generally, `Debug` and `Display` should be used instead of `.description()`, mainly due to the inflexibility in error formatting). This may break existing code, which is why this PR is version breaking. 

Right now the tests are failing (because the tests are stringly typed - again, please don't do this, changing the format of an error message should not break tests, the error should be independent of its formatting). I'll fix that shortly (making the test strongly typed).