### PR TITLE
Better handle/ignore doctypes

### DIFF
--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -43,7 +43,6 @@ impl From<io::Error> for EmitterError {
 
 impl fmt::Display for EmitterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::error::Error;
 
         write!(f, "emitter error: ")?;
         match *self {

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -386,7 +386,7 @@ fn test(input: &[u8], output: &[u8], config: ParserConfig, test_position: bool) 
                 if line != spec {
                     const SPLITTER: &'static str = "-------------------";
                     panic!("\n{}\nUnexpected event at line {}:\nExpected: {}\nFound:    {}\n{}\n",
-                           SPLITTER, n + 1, spec, line, SPLITTER);
+                           SPLITTER, n + 1, spec, line, std::str::from_utf8(output).unwrap());
                 }
             } else {
                 panic!("Unexpected event: {}", line);
@@ -446,13 +446,13 @@ impl<'a> fmt::Display for Event<'a> {
                 XmlEvent::EndElement { ref name } =>
                     write!(f, "EndElement({})", Name(name)),
                 XmlEvent::Comment(ref data) =>
-                    write!(f, "Comment({:?})", data),
+                    write!(f, r#"Comment("{}")"#, data.escape_debug()),
                 XmlEvent::CData(ref data) =>
-                    write!(f, "CData({:?})", data),
+                    write!(f, r#"CData("{}")"#, data.escape_debug()),
                 XmlEvent::Characters(ref data) =>
-                    write!(f, "Characters({:?})", data),
+                    write!(f, r#"Characters("{}")"#, data.escape_debug()),
                 XmlEvent::Whitespace(ref data) =>
-                    write!(f, "Whitespace({:?})", data),
+                    write!(f, r#"Whitespace("{}")"#, data.escape_debug()),
             },
             Err(ref e) => e.fmt(f),
         }


### PR DESCRIPTION
This PR adjusts xml-rs to better ignore the contents of a DTD in an xml file, solving #170.  This just skips the entire DTD in the lexer for now.

I also ran into this for some xml files locally, but also did not need the DTD information.

This PR also fixes a compiler warning and the test suite failures caused by upgrading to rust 1.28.