### PR TITLE
Remove use of unsafe in favor of lazy_static!. Round 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ path = "src/lib.rs"
 name = "xml-analyze"
 path = "src/analyze.rs"
 
-[dependencies]
+[dev-dependencies]
 lazy_static = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/lib.rs"
 [[bin]]
 name = "xml-analyze"
 path = "src/analyze.rs"
+
+[dependencies]
+lazy_static = "1.2.0"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate xml;
 
 use std::cmp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![forbid(non_camel_case_types)]
+#![forbid(unsafe_code)]
 
 //! This crate currently provides an almost XML 1.0/1.1-compliant pull parser.
 

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate xml;
 #[macro_use]
 extern crate lazy_static;

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -339,6 +339,10 @@ fn issue_attribues_have_no_default_namespace () {
 }
 
 lazy_static! {
+    // If PRINT_SPEC env variable is set, print the lines
+    // to stderr instead of comparing with the output
+    // it can be used like this:
+    // PRINT_SPEC=1 cargo test --test event_reader sample_1_full 2> sample_1_full.txt
     static ref PRINT: bool = {
         for (key, value) in env::vars() {
             if key == "PRINT_SPEC" && value == "1" {
@@ -359,11 +363,6 @@ fn trim_until_bar(s: String) -> String {
 }
 
 fn test(input: &[u8], output: &[u8], config: ParserConfig, test_position: bool) {
-    // If PRINT_SPEC env variable is set, print the lines
-    // to stderr instead of comparing with the output
-    // it can be used like this:
-    // PRINT_SPEC=1 cargo test --test event_reader sample_1_full 2> sample_1_full.txt
-
     let mut reader = config.create_reader(input);
     let mut spec_lines = BufReader::new(output).lines()
         .map(|line| line.unwrap())

--- a/tests/event_writer.rs
+++ b/tests/event_writer.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate xml;
 
 use std::io::{BufReader, SeekFrom};

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate xml;
 
 use std::io::{Cursor, Write};


### PR DESCRIPTION
This builds upon and closes https://github.com/netvl/xml-rs/pull/172

* Addressed review feedback from that PR:
  * Moved comment
  * Made lazy_static only a `[dev-dependencies]`
* Added `#![forbid(unsafe_code)]` to all entry points, which makes tools like `cargo geiger` happy.  These can of course be removed in the future if a good reason to use unsafe code comes up, but one of the big draws of this library, to me, is that it's - so far - 100% safe rust code.  Which makes me a lot less nervous about parsing potentially hostile/malicious user input with it.