### PR TITLE
Update to nom_locate 2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,17 @@ harness = false
 [dependencies]
 encoding_rs = "0.8.17"
 nom = "5.1.0"
-nom_locate = { git = "https://github.com/fflorent/nom_locate" }
+nom_locate = "2.0.0"
 combine = "4.0.1"
 thiserror = "1.0.9"
 derive_more = "0.99.2"
 arraydeque = "0.4.5"
-aho-corasick = "0.7.6"
+aho-corasick = "0.7.10"
 
 [dev-dependencies]
-quickcheck = "0.8.5"
-criterion = "0.2.11"
-rand = "0.7.0"
+quickcheck = "0.9.2"
+criterion = "0.3.1"
+rand = "0.7.3"
 encoding = "0.2.33"
 itertools = "0.8.2"
 regex = "1.3.3"

--- a/src/reader/reading/logic/mod.rs
+++ b/src/reader/reading/logic/mod.rs
@@ -151,11 +151,11 @@ impl ParserLogic {
         };
         let (remainder, Parsed { event, hint, span }) = result?;
         self.position.advance_both(
-            span.line.saturating_sub(1) as u64,
+            span.location_line().saturating_sub(1) as u64,
             span.get_utf8_column().saturating_sub(1) as u64,
         );
 
-        let mut output = ParserLogicOutput::new(input.fragment.len() - remainder.fragment.len());
+        let mut output = ParserLogicOutput::new(input.fragment().len() - remainder.fragment().len());
 
         let event = match event {
             model::Event::CData(data) if self.config.cdata_to_text => model::Event::text(data),

--- a/src/reader/reading/mod.rs
+++ b/src/reader/reading/mod.rs
@@ -109,7 +109,7 @@ impl<R: StrRead> Reader<R> {
 
                 Err(ParserLogicError::Parsing(e)) => {
                     let e = VerboseError {
-                        errors: e.errors.into_iter().map(|(span, vek)| (span.fragment, vek)).collect(),
+                        errors: e.errors.into_iter().map(|(span, vek)| (*span.fragment(), vek)).collect(),
                     };
                     return Err(Error::new((slice, e), self.position()));
                 }


### PR DESCRIPTION
nom_locate 2.0 released in February, makes some formerly-public
struct fields private and replaces them with method calls.