### PR TITLE
Add pad_self_closing config option

### DIFF
--- a/src/writer/config.rs
+++ b/src/writer/config.rs
@@ -73,6 +73,15 @@ pub struct EmitterConfig {
     /// comments text in order to get more pretty comments: `<!-- something -->` instead of
     /// `<!--something-->`.
     pub autopad_comments: bool,
+
+    /// Whether or not to automatically insert spaces before the trailing `/>` in self-closing
+    /// elements. Default is true.
+    ///
+    /// This option is only meaningful if `normalize_empty_elements` is true. For example, the
+    /// element `<a></a>` would be unaffected. When `normalize_empty_elements` is true, then when
+    /// this option is also true, the same element would appear `<a />`. If this option is false,
+    /// then the same element would appear `<a/>`.
+    pub pad_self_closing: bool,
 }
 
 impl EmitterConfig {
@@ -99,7 +108,8 @@ impl EmitterConfig {
             normalize_empty_elements: true,
             cdata_to_characters: false,
             keep_element_names_stack: true,
-            autopad_comments: true
+            autopad_comments: true,
+            pad_self_closing: true
         }
     }
 
@@ -142,5 +152,6 @@ gen_setters!(EmitterConfig,
     normalize_empty_elements: val bool,
     cdata_to_characters: val bool,
     keep_element_names_stack: val bool,
-    autopad_comments: val bool
+    autopad_comments: val bool,
+    pad_self_closing: val bool
 );

--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -365,8 +365,8 @@ impl Emitter {
         if let Some(name) = owned_name.as_ref().map(|n| n.borrow()).or(name) {
             if self.config.normalize_empty_elements && self.just_wrote_start_element {
                 self.just_wrote_start_element = false;
-                // TODO: make this space configurable
-                let result = target.write(b" />").map_err(From::from);
+                let termination = if self.config.pad_self_closing { " />" } else { "/>" };
+                let result = target.write(termination.as_bytes()).map_err(From::from);
                 self.after_end_element();
                 result.map(|_| ())
             } else {

--- a/tests/event_writer.rs
+++ b/tests/event_writer.rs
@@ -132,6 +132,28 @@ fn writing_empty_elements_without_pad_self_closing() {
 
     assert_eq!(str::from_utf8(&b).unwrap(), r#"<hello><world/></hello>"#);
 }
+#[test]
+fn writing_empty_elements_pad_self_closing_explicit() {
+    use xml::writer::XmlEvent;
+
+    let mut b = Vec::new();
+
+    {
+        let mut w = EmitterConfig::new()
+            .write_document_declaration(false)
+            .pad_self_closing(true)
+            .create_writer(&mut b);
+
+        unwrap_all! {
+            w.write(XmlEvent::start_element("hello"));
+            w.write(XmlEvent::start_element("world"));
+            w.write(XmlEvent::end_element());
+            w.write(XmlEvent::end_element())
+        }
+    }
+
+    assert_eq!(str::from_utf8(&b).unwrap(), r#"<hello><world /></hello>"#);
+}
 
 #[test]
 fn writing_comments_with_indentation() {

--- a/tests/event_writer.rs
+++ b/tests/event_writer.rs
@@ -111,6 +111,29 @@ fn writing_empty_elements_without_normalizing() {
 }
 
 #[test]
+fn writing_empty_elements_without_pad_self_closing() {
+    use xml::writer::XmlEvent;
+
+    let mut b = Vec::new();
+
+    {
+        let mut w = EmitterConfig::new()
+            .write_document_declaration(false)
+            .pad_self_closing(false)
+            .create_writer(&mut b);
+
+        unwrap_all! {
+            w.write(XmlEvent::start_element("hello"));
+            w.write(XmlEvent::start_element("world"));
+            w.write(XmlEvent::end_element());
+            w.write(XmlEvent::end_element())
+        }
+    }
+
+    assert_eq!(str::from_utf8(&b).unwrap(), r#"<hello><world/></hello>"#);
+}
+
+#[test]
 fn writing_comments_with_indentation() {
     use xml::writer::XmlEvent;
 


### PR DESCRIPTION
This config option sets whether to add a space before `/>` in
self-closing tags. Example behavior:
true -> `<a />`,
false -> `<a/>`

This commit also adds a single test to test the `false` case of this config
option, as it is set to `true` by default.