### PR TITLE
Always allow surrogate pair entity references

### DIFF
--- a/src/reader/parser/inside_reference.rs
+++ b/src/reader/parser/inside_reference.rs
@@ -31,7 +31,7 @@ impl PullParser {
                         if num_str == "0" {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
-                            match u32::from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
+                            match u32::from_str_radix(num_str, 16).ok().map(|i| char::from_u32(i).unwrap_or('\u{fffd}')) {
                                 Some(c) => Ok(c.to_string()),
                                 None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
                             }
@@ -42,7 +42,7 @@ impl PullParser {
                         if num_str == "0" {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
-                            match u32::from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
+                            match u32::from_str_radix(num_str, 10).ok().map(|i| char::from_u32(i).unwrap_or('\u{fffd}')) {
                                 Some(c) => Ok(c.to_string()),
                                 None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
                             }

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -340,6 +340,43 @@ fn issue_attribues_have_no_default_namespace () {
     );
 }
 
+#[test]
+fn issue_replacement_character_entity_reference() {
+    test(
+        br#"<doc>&#55357;&#56628;</doc>"#,
+        format!(
+            r#"
+                |StartDocument(1.0, UTF-8)
+                |StartElement(doc)
+                |Characters("{replacement_character}{replacement_character}")
+                |EndElement(doc)
+                |EndDocument
+            "#,
+            replacement_character = "\u{fffd}"
+        )
+        .as_bytes(),
+        ParserConfig::new(),
+        false,
+    );
+
+    test(
+        br#"<doc>&#xd83d;&#xdd34;</doc>"#,
+        format!(
+            r#"
+                |StartDocument(1.0, UTF-8)
+                |StartElement(doc)
+                |Characters("{replacement_character}{replacement_character}")
+                |EndElement(doc)
+                |EndDocument
+            "#,
+            replacement_character = "\u{fffd}"
+        )
+        .as_bytes(),
+        ParserConfig::new(),
+        false,
+    );
+}
+
 lazy_static! {
     // If PRINT_SPEC env variable is set, print the lines
     // to stderr instead of comparing with the output


### PR DESCRIPTION
Make the parser always successfully parse XML documents that contain entity references for surrogate pairs.

A document that contains a character entity reference that resolves to a surrogate pair – for example `<doc>&#xd83d;&#xdd34;</doc>` – is *technically* invalid according to the XML specification. However, replacing these with U+FFFD is both better for the consuming application (because the application does not need to do some weird pre-processing of the document before parsing it) and has precedent in that the standard Go XML parser in its standard configuration replaces these with U+FFFD.

---

Fixes #187

_Note: this is mutually exclusive with #189_