### PR TITLE
Option to allow surrogate pair entity references 

### DIFF
--- a/src/reader/config.rs
+++ b/src/reader/config.rs
@@ -74,7 +74,14 @@ pub struct ParserConfig {
     ///
     /// Note that support for this functionality is incomplete; for example, the parser will fail if
     /// the premature end of stream happens inside PCDATA. Therefore, use this option at your own risk.
-    pub ignore_end_of_stream: bool
+    pub ignore_end_of_stream: bool,
+
+    /// Whether or not non-unicode entity references get replaced with the replacement character
+    ///
+    /// When true, any decimal or hexadecimal character reference that cannot be converted from a
+    /// u32 to a char using [std::char::from_u32](https://doc.rust-lang.org/std/char/fn.from_u32.html)
+    /// will be converted into the unicode REPLACEMENT CHARACTER (U+FFFD).
+    pub replace_unknown_entity_references: bool,
 }
 
 impl ParserConfig {
@@ -98,7 +105,8 @@ impl ParserConfig {
             ignore_comments: true,
             coalesce_characters: true,
             extra_entities: HashMap::new(),
-            ignore_end_of_stream: false
+            ignore_end_of_stream: false,
+            replace_unknown_entity_references: false,
         }
     }
 
@@ -160,5 +168,6 @@ gen_setters! { ParserConfig,
     cdata_to_characters: val bool,
     ignore_comments: val bool,
     coalesce_characters: val bool,
-    ignore_end_of_stream: val bool
+    ignore_end_of_stream: val bool,
+    replace_unknown_entity_references: val bool
 }

--- a/src/reader/parser/inside_reference.rs
+++ b/src/reader/parser/inside_reference.rs
@@ -31,9 +31,16 @@ impl PullParser {
                         if num_str == "0" {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
-                            match u32::from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
-                                Some(c) => Ok(c.to_string()),
-                                None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
+                            if self.config.replace_unknown_entity_references {
+                                match u32::from_str_radix(num_str, 16).ok().map(|i| char::from_u32(i).unwrap_or('\u{fffd}')) {
+                                    Some(c) => Ok(c.to_string()),
+                                    None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
+                                }
+                            } else {
+                                match u32::from_str_radix(num_str, 16).ok().and_then(char::from_u32) {
+                                    Some(c) => Ok(c.to_string()),
+                                    None    => Err(self_error!(self; "Invalid hexadecimal character number in an entity: {}", name))
+                                }
                             }
                         }
                     }
@@ -42,9 +49,17 @@ impl PullParser {
                         if num_str == "0" {
                             Err(self_error!(self; "Null character entity is not allowed"))
                         } else {
-                            match u32::from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
-                                Some(c) => Ok(c.to_string()),
-                                None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
+                            if self.config.replace_unknown_entity_references {
+                                match u32::from_str_radix(num_str, 10).ok().map(|i| char::from_u32(i).unwrap_or('\u{fffd}')) {
+                                    Some(c) => Ok(c.to_string()),
+                                    None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
+                                }
+                            }
+                            else {
+                                match u32::from_str_radix(num_str, 10).ok().and_then(char::from_u32) {
+                                    Some(c) => Ok(c.to_string()),
+                                    None    => Err(self_error!(self; "Invalid decimal character number in an entity: {}", name))
+                                }
                             }
                         }
                     },

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -340,6 +340,67 @@ fn issue_attribues_have_no_default_namespace () {
     );
 }
 
+#[test]
+fn issue_replacement_character_entity_reference() {
+    test(
+        br#"<doc>&#55357;&#56628;</doc>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(doc)
+            |1:13 Invalid decimal character number in an entity: #55357
+        "#,
+        ParserConfig::new(),
+        false,
+    );
+
+    test(
+        br#"<doc>&#xd83d;&#xdd34;</doc>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(doc)
+            |1:13 Invalid hexadecimal character number in an entity: #xd83d
+        "#,
+        ParserConfig::new(),
+        false,
+    );
+
+    test(
+        br#"<doc>&#55357;&#56628;</doc>"#,
+        format!(
+            r#"
+                |StartDocument(1.0, UTF-8)
+                |StartElement(doc)
+                |Characters("{replacement_character}{replacement_character}")
+                |EndElement(doc)
+                |EndDocument
+            "#,
+            replacement_character = "\u{fffd}"
+        )
+        .as_bytes(),
+        ParserConfig::new()
+            .replace_unknown_entity_references(true),
+        false,
+    );
+
+    test(
+        br#"<doc>&#xd83d;&#xdd34;</doc>"#,
+        format!(
+            r#"
+                |StartDocument(1.0, UTF-8)
+                |StartElement(doc)
+                |Characters("{replacement_character}{replacement_character}")
+                |EndElement(doc)
+                |EndDocument
+            "#,
+            replacement_character = "\u{fffd}"
+        )
+        .as_bytes(),
+        ParserConfig::new()
+            .replace_unknown_entity_references(true),
+        false,
+    );
+}
+
 lazy_static! {
     // If PRINT_SPEC env variable is set, print the lines
     // to stderr instead of comparing with the output


### PR DESCRIPTION
Make it possible for the parser to successfully parse an XML document that contains entity references for surrogate pairs.

A document that contains a character entity reference that resolves to a surrogate pair – for example `<doc>&#xd83d;&#xdd34;</doc>` – is *technically* invalid according to the XML specification. However, replacing these with U+FFFD is both better for the consuming application (because the application does not need to do some weird pre-processing of the document before parsing it) and has precedent in that the standard Go XML parser in its standard configuration replaces these with U+FFFD.

Add an option – disabled by default – to ParserConfig that allows this translation when these entity references are encountered.

---

Fixes #187

_Note: this is mutually exclusive with #188_