### PR TITLE
adds ParseConfig ignore_root_level_whitespace option

### DIFF
--- a/src/reader/config.rs
+++ b/src/reader/config.rs
@@ -82,6 +82,12 @@ pub struct ParserConfig {
     /// u32 to a char using [std::char::from_u32](https://doc.rust-lang.org/std/char/fn.from_u32.html)
     /// will be converted into the unicode REPLACEMENT CHARACTER (U+FFFD).
     pub replace_unknown_entity_references: bool,
+
+    /// Whether or not whitespace at the root level of the document is ignored. Default is true.
+    ///
+    /// By default any whitespace that is not enclosed within at least one level of elements will be
+    /// ignored. Setting this value to false will cause root level whitespace events to be emitted.
+    pub ignore_root_level_whitespace: bool,
 }
 
 impl ParserConfig {
@@ -107,6 +113,7 @@ impl ParserConfig {
             extra_entities: HashMap::new(),
             ignore_end_of_stream: false,
             replace_unknown_entity_references: false,
+            ignore_root_level_whitespace: true,
         }
     }
 
@@ -169,5 +176,6 @@ gen_setters! { ParserConfig,
     ignore_comments: val bool,
     coalesce_characters: val bool,
     ignore_end_of_stream: val bool,
-    replace_unknown_entity_references: val bool
+    replace_unknown_entity_references: val bool,
+    ignore_root_level_whitespace: val bool
 }

--- a/src/reader/parser/outside_tag.rs
+++ b/src/reader/parser/outside_tag.rs
@@ -14,10 +14,7 @@ impl PullParser {
             Token::ReferenceStart =>
                 self.into_state_continue(State::InsideReference(Box::new(State::OutsideTag))),
 
-            Token::Whitespace(_) if self.depth() == 0 => None,  // skip whitespace outside of the root element
-
-            _ if t.contains_char_data() && self.depth() == 0 =>
-                Some(self_error!(self; "Unexpected characters outside the root element: {}", t)),
+            Token::Whitespace(_) if self.depth() == 0 && self.config.ignore_root_level_whitespace => None,  // skip whitespace outside of the root element
 
             Token::Whitespace(_) if self.config.trim_whitespace && !self.buf_has_data() => None,
 
@@ -27,6 +24,9 @@ impl PullParser {
                 }
                 self.append_char_continue(c)
             }
+
+            _ if t.contains_char_data() && self.depth() == 0 =>
+                Some(self_error!(self; "Unexpected characters outside the root element: {}", t)),
 
             _ if t.contains_char_data() => {  // Non-whitespace char data
                 if !self.buf_has_data() {

--- a/tests/documents/sample_6.xml
+++ b/tests/documents/sample_6.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="doc.xsl"?>
+
+<doc>Hello</doc>

--- a/tests/documents/sample_6_full.txt
+++ b/tests/documents/sample_6_full.txt
@@ -1,0 +1,8 @@
+StartDocument(1.0, UTF-8)
+Whitespace("\n")
+ProcessingInstruction(xml-stylesheet="href=\"doc.xsl\"")
+Whitespace("\n\n")
+StartElement(doc)
+Characters("Hello")
+EndElement(doc)
+EndDocument

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -168,6 +168,22 @@ fn sample_5_short() {
 }
 
 #[test]
+fn sample_6_full() {
+    test(
+        include_bytes!("documents/sample_6.xml"),
+        include_bytes!("documents/sample_6_full.txt"),
+        ParserConfig::new()
+            .ignore_root_level_whitespace(false)
+            .ignore_comments(false)
+            .whitespace_to_characters(false)
+            .cdata_to_characters(false)
+            .trim_whitespace(false)
+            .coalesce_characters(false),
+        false
+    );
+}
+
+#[test]
 fn eof_1() {
     test(
         br#"<?xml"#,


### PR DESCRIPTION
While trying to implement XML canonicalization I realized I couldn't distinguish between the following documents:
```
<a/><a/>
```
```
<a/>
<a/>
```
```
<a/>

<a/>
```

This is because the newline isn't emitted because it's at the root level.

This extra flag will cause a new line to be emitted, which will provide enough information to do proper canonicalization.