### PR TITLE
Attempted to fix the parsing as characters of ]]> and ?>

### DIFF
--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -127,7 +127,7 @@ impl Token {
     pub fn contains_char_data(&self) -> bool {
         match *self {
             Token::Whitespace(_) | Token::Chunk(_) | Token::Character(_) | Token::CommentEnd |
-            Token::TagEnd | Token::EqualsSign | Token::DoubleQuote | Token::SingleQuote => true,
+            Token::TagEnd | Token::EqualsSign | Token::DoubleQuote | Token::SingleQuote | Token::CDataEnd | Token::ProcessingInstructionEnd => true,
             _ => false
         }
     }

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -127,7 +127,8 @@ impl Token {
     pub fn contains_char_data(&self) -> bool {
         match *self {
             Token::Whitespace(_) | Token::Chunk(_) | Token::Character(_) | Token::CommentEnd |
-            Token::TagEnd | Token::EqualsSign | Token::DoubleQuote | Token::SingleQuote | Token::CDataEnd | Token::ProcessingInstructionEnd => true,
+            Token::TagEnd | Token::EqualsSign | Token::DoubleQuote | Token::SingleQuote | Token::CDataEnd | 
+            Token::ProcessingInstructionEnd | Token::EmptyTagEnd => true,
             _ => false
         }
     }

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -275,6 +275,22 @@ fn issue_unescaped_processing_instruction_end() {
 }
 
 #[test]
+fn issue_unescaped_empty_tag_end() {
+    test(
+        br#"<hello>/></hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("/>")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false
+    );
+}
+
+#[test]
 fn issue_83_duplicate_attributes() {
     test(
         br#"<hello><some-tag a='10' a="20"></hello>"#,

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -243,6 +243,38 @@ fn tabs_1() {
 }
 
 #[test]
+fn issue_32_unescaped_cdata_end() {
+    test(
+        br#"<hello>]]></hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("]]>")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false
+    );
+}
+
+#[test]
+fn issue_unescaped_processing_instruction_end() {
+    test(
+        br#"<hello>?></hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("?>")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false
+    );
+}
+
+#[test]
 fn issue_83_duplicate_attributes() {
     test(
         br#"<hello><some-tag a='10' a="20"></hello>"#,


### PR DESCRIPTION
I was playing around with xml-rs in my own project (https://github.com/jdalberg/cwmp) and decided to use QuickCheck for validation. So a bunch of randomness into fields, generate some xml, parse it and compare with input with different permutation of content, and came across what I consider to be a bug in the parser. It would not recoqnice: "?>" as characters.

Looking into xml-rs i could see that in line 127 of reader/lexer.rs the token for "?>" was missing from the function, looking at issue #32 i introduced two new testcases and the two tokens for "]]>" and "?>" in the list of token that are possibly characters.