### PR TITLE
Encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ path = "src/lib.rs"
 name = "xml-analyze"
 path = "src/analyze.rs"
 
+[dependencies]
+encoding = "0.2"
+
 [dev-dependencies]
 doc-comment = "0.3"
 lazy_static = "1.2.0"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -22,7 +22,7 @@ macro_rules! abort {
 fn main() {
     let mut file;
     let mut stdin;
-    let source: &mut Read = match env::args().nth(1) {
+    let source: &mut dyn Read = match env::args().nth(1) {
         Some(file_name) => {
             file = File::open(file_name)
                 .unwrap_or_else(|e| abort!(1, "Cannot open input file: {}", e));

--- a/src/common.rs
+++ b/src/common.rs
@@ -117,13 +117,13 @@ pub fn is_whitespace_str(s: &str) -> bool {
 /// [1]: http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-common-syn
 pub fn is_name_start_char(c: char) -> bool {
     match c {
-        ':' | 'A'...'Z' | '_' | 'a'...'z' |
-        '\u{C0}'...'\u{D6}' | '\u{D8}'...'\u{F6}' | '\u{F8}'...'\u{2FF}' |
-        '\u{370}'...'\u{37D}' | '\u{37F}'...'\u{1FFF}' |
-        '\u{200C}'...'\u{200D}' | '\u{2070}'...'\u{218F}' |
-        '\u{2C00}'...'\u{2FEF}' | '\u{3001}'...'\u{D7FF}' |
-        '\u{F900}'...'\u{FDCF}' | '\u{FDF0}'...'\u{FFFD}' |
-        '\u{10000}'...'\u{EFFFF}' => true,
+        ':' | 'A'..='Z' | '_' | 'a'..='z' |
+        '\u{C0}'..='\u{D6}' | '\u{D8}'..='\u{F6}' | '\u{F8}'..='\u{2FF}' |
+        '\u{370}'..='\u{37D}' | '\u{37F}'..='\u{1FFF}' |
+        '\u{200C}'..='\u{200D}' | '\u{2070}'..='\u{218F}' |
+        '\u{2C00}'..='\u{2FEF}' | '\u{3001}'..='\u{D7FF}' |
+        '\u{F900}'..='\u{FDCF}' | '\u{FDF0}'..='\u{FFFD}' |
+        '\u{10000}'..='\u{EFFFF}' => true,
         _ => false
     }
 }
@@ -135,8 +135,8 @@ pub fn is_name_start_char(c: char) -> bool {
 pub fn is_name_char(c: char) -> bool {
     match c {
         _ if is_name_start_char(c) => true,
-        '-' | '.' | '0'...'9' | '\u{B7}' |
-        '\u{300}'...'\u{36F}' | '\u{203F}'...'\u{2040}' => true,
+        '-' | '.' | '0'..='9' | '\u{B7}' |
+        '\u{300}'..='\u{36F}' | '\u{203F}'..='\u{2040}' => true,
         _ => false
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 #[macro_use]
 extern crate doc_comment;
 
+extern crate encoding;
+
 #[cfg(doctest)]
 doctest!("../Readme.md");
 

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -118,4 +118,4 @@ impl PartialEq for ErrorKind {
 }
 impl Eq for ErrorKind {}
 
-fn error_description(e: &error::Error) -> &str { e.description() }
+fn error_description(e: &dyn error::Error) -> &str { e.description() }

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -13,6 +13,7 @@ pub enum ErrorKind {
     Syntax(Cow<'static, str>),
     Io(io::Error),
     Utf8(str::Utf8Error),
+    Encoding(Cow<'static, str>),
     UnexpectedEof,
 }
 
@@ -46,6 +47,7 @@ impl Error {
             Utf8(ref reason) => error_description(reason),
             Io(ref io_error) => error_description(io_error),
             Syntax(ref msg) => msg.as_ref(),
+            Encoding(ref msg) => msg.as_ref(),
         }
     }
 
@@ -89,6 +91,15 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<Cow<'static, str>> for Error {
+    fn from(e: Cow<'static, str>) -> Self {
+        Error {
+            pos: TextPosition::new(),
+            kind: ErrorKind::Encoding(e),
+        }
+    }
+}
+
 impl Clone for ErrorKind {
     fn clone(&self) -> Self {
         use self::ErrorKind::*;
@@ -97,6 +108,7 @@ impl Clone for ErrorKind {
             Utf8(ref reason) => Utf8(reason.clone()),
             Io(ref io_error) => Io(io::Error::new(io_error.kind(), error_description(io_error))),
             Syntax(ref msg) => Syntax(msg.clone()),
+            Encoding(ref msg) => Encoding(msg.clone()),
         }
     }
 }

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -292,7 +292,7 @@ impl Lexer {
 
         // Check if we have saved a char or two for ourselves
         while let Some(c) = self.char_queue.pop_front() {
-            match try!(self.read_next_token(c)) {
+            match self.read_next_token(c)? {
                 Some(t) => {
                     self.inside_token = false;
                     return Ok(Some(t));
@@ -303,12 +303,12 @@ impl Lexer {
 
         loop {
             // TODO: this should handle multiple encodings
-            let c = match try!(util::next_char_from(b)) {
+            let c = match util::next_char_from(b)? {
                 Some(c) => c,   // got next char
                 None => break,  // nothing to read left
             };
 
-            match try!(self.read_next_token(c)) {
+            match self.read_next_token(c)? {
                 Some(t) => {
                     self.inside_token = false;
                     return Ok(Some(t));

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,7 +62,6 @@ mod tests {
     #[test]
     fn test_next_char_from() {
         use std::io;
-        use std::error::Error;
 
         let mut bytes: &[u8] = "correct".as_bytes();    // correct ASCII
         assert_eq!(super::next_char_from(&mut bytes).unwrap(), Some('c'));
@@ -100,7 +99,7 @@ mod tests {
         let mut r = ErrorReader;
         match super::next_char_from(&mut r).unwrap_err() {
             super::CharReadError::Io(ref e) if e.kind() == io::ErrorKind::Other &&
-                                               e.description() == "test error" => {},
+                                               e.to_string() == "test error" => {},
             e => panic!("Unexpected result: {:?}", e)
         }
     }

--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -49,7 +49,7 @@ impl fmt::Display for EmitterError {
             EmitterError::Io(ref e) =>
                 write!(f, "I/O error: {}", e),
             ref other =>
-                write!(f, "{}", other.description()),
+                write!(f, "{}", other),
         }
     }
 }

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -21,8 +21,8 @@ use xml::reader::{Result, XmlEvent, ParserConfig, EventReader};
 #[allow(dead_code)]
 fn count_event_in_file(name: &Path) -> Result<usize> {
     let mut event_count = 0;
-    for event in EventReader::new(BufReader::new(try!(File::open(name)))) {
-        try!(event);
+    for event in EventReader::new(BufReader::new(File::open(name)?)) {
+        event?;
         event_count += 1;
     }
     Ok(event_count)
@@ -487,11 +487,11 @@ struct Name<'a>(&'a OwnedName);
 impl <'a> fmt::Display for Name<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(ref namespace) = self.0.namespace {
-            try! { write!(f, "{{{}}}", namespace) }
+            write!(f, "{{{}}}", namespace)?
         }
 
         if let Some(ref prefix) = self.0.prefix {
-            try! { write!(f, "{}:", prefix) }
+            write!(f, "{}:", prefix)?
         }
 
         write!(f, "{}", self.0.local_name)


### PR DESCRIPTION
- fix some basic warnings like `try!()` -> `?`
- parse the encoding whatwg label
- convert text in `XmlEvent::Characters` to `utf-8` if a different encoding was detected

Basic idea was discussed here: https://github.com/feed-rs/feed-rs/issues/58