### PR TITLE
Fix issue #168:  Force XML document declaration to be output before 'characters' event

### DIFF
--- a/src/writer/emitter.rs
+++ b/src/writer/emitter.rs
@@ -401,6 +401,7 @@ impl Emitter {
 
     pub fn emit_characters<W: Write>(&mut self, target: &mut W,
                                       content: &str) -> Result<()> {
+        self.check_document_started(target)?;
         self.fix_non_empty_element(target)?;
         target.write(
             (if self.config.perform_escaping {


### PR DESCRIPTION
The 'characters' writer event could not be used to output text after
the document declaration, only before it or after the first XML element.
This change ensures that the document declaration will be output before
the text.  Arbitrary text can still be output at the start of the file,
if needed, by writing directly using the inner_mut method.

Addresses issue #168.