### PR TITLE
Fix parsing `/>` in content

### DIFF
--- a/src/reader/parser/outside_tag.rs
+++ b/src/reader/parser/outside_tag.rs
@@ -58,6 +58,15 @@ impl PullParser {
                 self.into_state_continue(State::InsideCData)
             }
 
+            Token::EmptyTagEnd => { // Bare '/>' in text
+                if !self.buf_has_data() {
+                    self.push_pos();
+                }
+                self.inside_whitespace = false;
+                Token::EmptyTagEnd.push_to_string(&mut self.buf);
+                self.into_state_continue(State::OutsideTag)
+            }
+
             _ => {
                 // Encountered some markup event, flush the buffer as characters
                 // or a whitespace

--- a/tests/event_reader.rs
+++ b/tests/event_reader.rs
@@ -417,6 +417,61 @@ fn issue_replacement_character_entity_reference() {
     );
 }
 
+#[test]
+fn issue_document_contains_slash_gt() {
+    test(
+        br#"<hello>/></hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("/>")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false,
+    );
+
+    test(
+        br#"<hello>a/>a</hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("a/>a")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false,
+    );
+
+    test(
+        br#"<hello>  />  </hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("  />  ")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new(),
+        false,
+    );
+
+    test(
+        br#"<hello>  />  </hello>"#,
+        br#"
+            |StartDocument(1.0, UTF-8)
+            |StartElement(hello)
+            |Characters("/>")
+            |EndElement(hello)
+            |EndDocument
+        "#,
+        ParserConfig::new().trim_whitespace(true),
+        false,
+    );
+}
+
 lazy_static! {
     // If PRINT_SPEC env variable is set, print the lines
     // to stderr instead of comparing with the output


### PR DESCRIPTION
Fix an issue where xml-rs fails to parse `/>` in content.

For example, this is a perfectly valid document according to the spec
and other XML parsers:

```xml
<hello>/></hello>
```

Per https://www.w3.org/TR/REC-xml/#syntax

> The ampersand character (&) and the left angle bracket (<) must not
> appear in their literal form, except when used as markup delimiters, or
> within a comment, a processing instruction, or a CDATA section. If they
> are needed elsewhere, they must be escaped using either numeric
> character references or the strings " & " and " < " respectively. The
> right angle bracket (>) may be represented using the string " > ", and
> must, for compatibility, be escaped using either " > " or a character
> reference when it appears in the string " ]]> " in content, when that
> string is not marking the end of a CDATA section.

Fixes #207