### PR TITLE
reader: add from_bytes() convenience function that strips any BOM

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -126,4 +126,18 @@ impl<'r> EventReader<&'r [u8]> {
     pub fn from_str(source: &'r str) -> EventReader<&'r [u8]> {
         EventReader::new(source.as_bytes())
     }
+
+    /// A convenience method to create an `XmlReader` from a bunch of bytes.
+    /// Unlike `EventReader::from_str()` this function will skip an UTF-8 BOM
+    /// at the beginning of the data (which would otherwise trigger an UTF-8
+    /// character validation error later).
+    #[inline]
+    pub fn from_bytes(data: &'r [u8]) -> EventReader<&'r [u8]> {
+        const UTF8_BOM: &[u8] = &[0xef, 0xbb, 0xbf];
+
+        // UTF-8 data from external sources might have a BOM at the beginning,
+        // which we'll need to strip before passing the data to the parser.
+        let stripped_data = data.strip_prefix(UTF8_BOM).unwrap_or(data);
+        EventReader::new(stripped_data)
+    }
 }

--- a/tests/documents/bom.xml
+++ b/tests/documents/bom.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0"?>
+<?xml-stylesheet href="doc.xsl"?>
+
+<doc>Hello</doc>


### PR DESCRIPTION
XML coming from external sources sometimes has an UTF-8 marker at
the beginning, which is invalid UTF-8 and will cause parse errors,
so add a from_bytes() convenience method that strips such BOMs at
the beginning.