### PR TITLE
Improve documentation for `EventReader::next`

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -45,8 +45,8 @@ impl<R: Read> EventReader<R> {
 
     /// Pulls and returns next XML event from the stream.
     ///
-    /// If returned event is `XmlEvent::Error` or `XmlEvent::EndDocument`, then
-    /// further calls to this method will return this event again.
+    /// If the call fails or the returned event is [`XmlEvent::EndDocument`],
+    /// further calls to this method will return the same result.
     #[inline]
     pub fn next(&mut self) -> Result<XmlEvent> {
         self.parser.next(&mut self.source)


### PR DESCRIPTION
It mentioned an `XmlEvent::Error` which does not exist (anymore?) also updated some of the wording while at it.