### PR TITLE
Avoid panic when displaying unexpected token error

### DIFF
--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -81,6 +81,7 @@ impl fmt::Display for Token {
                 Token::EqualsSign                 => "=",
                 Token::SingleQuote                => "'",
                 Token::DoubleQuote                => "\"",
+                Token::MarkupDeclarationStart     => "<!",
                 _                          => unreachable!()
             }.fmt(f),
         }


### PR DESCRIPTION
Avoid entering `unreachable!()` when displaying an error message for an invalid `<!` token. This fixes a panic when processing a malformed XML which contains such token in an unexpected place.

Find below a minimal reproducer and the resulting backtrace:

```rust
use std::io;
use xml::ParserConfig;

fn main() {
    let source = "<!DOCTYPEs/%<!A";
    let parser = ParserConfig::new()
        .cdata_to_characters(true)
        .ignore_comments(true)
        .coalesce_characters(false)
        .create_reader(io::Cursor::new(source));
    for e in parser {
        println!("{:?}", e);
    }
}
```

```
Ok(StartDocument(1.0, UTF-8, None))
thread 'main' panicked at 'internal error: entered unreachable code', /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/xml-rs-0.8.13/src/reader/lexer.rs:84:47
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/panicking.rs:67:14
   2: core::panicking::panic
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/panicking.rs:117:5
   3: <xml::reader::lexer::Token as core::fmt::Display>::fmt
   4: core::fmt::rt::Argument::fmt
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/fmt/rt.rs:138:9
   5: core::fmt::write
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/fmt/mod.rs:1094:21
   6: core::fmt::Write::write_fmt
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/fmt/mod.rs:192:9
   7: alloc::fmt::format::format_inner
             at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/alloc/src/fmt.rs:610:16
   8: xml::reader::error::SyntaxError::to_cow
   9: xml::reader::parser::PullParser::error
  10: xml::reader::parser::PullParser::dispatch_token
  11: xml::reader::parser::PullParser::next
  12: xml_rs_crash::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

After applying the patch this is the reproducer output:

```
Ok(StartDocument(1.0, UTF-8, None))
Err(Error { pos: 1:13, kind: Syntax("Unexpected token inside entity: <!") })
```